### PR TITLE
ID DI

### DIFF
--- a/src/Microsoft.AspNet.Identity.Entity/IdentityContext.cs
+++ b/src/Microsoft.AspNet.Identity.Entity/IdentityContext.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.AspNet.DependencyInjection;
+using Microsoft.AspNet.DependencyInjection.Fallback;
 using Microsoft.Data.Entity;
 using Microsoft.Data.InMemory;
 using Microsoft.Data.Entity.Metadata;
@@ -8,8 +10,8 @@ namespace Microsoft.AspNet.Identity.Entity
     public class IdentityContext :
         IdentityContext<EntityUser, EntityRole, string, IdentityUserLogin, IdentityUserRole, IdentityUserClaim>
     {
-        public IdentityContext(EntityConfiguration config) : base(config) { }
         public IdentityContext() { }
+        public IdentityContext(IServiceProvider serviceProvider) : base(serviceProvider) { }
     }
 
     public class IdentityContext<TUser, TRole, TKey, TUserLogin, TUserRole, TUserClaim> : EntityContext
@@ -24,15 +26,25 @@ namespace Microsoft.AspNet.Identity.Entity
         public EntitySet<TUser> Users { get; set; }
         public EntitySet<TRole> Roles { get; set; }
 
-        public IdentityContext() { }
-        public IdentityContext(EntityConfiguration config) : base(config) { }
+        public IdentityContext(IServiceProvider serviceProvider)
+        : base(serviceProvider) { }
+
+        public IdentityContext()
+        : this(new ServiceCollection()
+            .AddEntityFramework(
+//#if NET45
+//          s => s.AddSqlServer()
+//#else
+            s => s.AddInMemoryStore()
+//#endif
+              ).BuildServiceProvider()) { }
 
         protected override void OnConfiguring(EntityConfigurationBuilder builder)
         {
 //#if NET45
-//            builder.UseSqlServer(@"Server=(localdb)\v11.0;Database=IdentityDb;Trusted_Connection=True;");
+//          builder.SqlServerConnectionString(@"Server=(localdb)\v11.0;Database=IdentityDb;Trusted_Connection=True;");
 //#else
-            builder.UseDataStore(new InMemoryDataStore());
+            builder.UseInMemoryStore(persist: true);
 //#endif
         }
 

--- a/test/Microsoft.AspNet.Identity.Entity.Test/TestIdentityFactory.cs
+++ b/test/Microsoft.AspNet.Identity.Entity.Test/TestIdentityFactory.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNet.Testing;
+using Microsoft.AspNet.DependencyInjection;
+using Microsoft.AspNet.DependencyInjection.Fallback;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
@@ -16,12 +18,11 @@ namespace Microsoft.AspNet.Identity.Entity.Test
     {
         public static EntityContext CreateContext()
         {
-            var configuration = new EntityConfigurationBuilder()
-                //.UseModel(model)
-                            .UseDataStore(new InMemoryDataStore())
-                            .BuildConfiguration();
+            var serviceProvider = new ServiceCollection()
+                        .AddEntityFramework(s => s.AddInMemoryStore())
+                        .BuildServiceProvider();
 
-            var db = new IdentityContext(configuration);
+            var db = new IdentityContext(serviceProvider);
             //            var sql = db.Configuration.DataStore as SqlServerDataStore;
             //            if (sql != null)
             //            {


### PR DESCRIPTION
ID DI (Update Identity to use EF DI/config)

Constructors that take IServiceProvider so it can be injected and also kept the parameterless constructor which will create its own DI container as before--not sure if this is desirable for Identity or not, but can be changed later.
