### PR TITLE
Add builder extensions to service collection

### DIFF
--- a/src/Microsoft.AspNet.Identity.Entity/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Identity.Entity/EntityServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.Entity;
+using Microsoft.Data.Entity;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public static class EntityServiceCollectionExtensions
+    {
+        public static ServiceCollection AddEntity<TUser>(this ServiceCollection services)
+            where TUser : User
+        {
+            services.AddScoped<IUserStore<TUser>, UserStore<TUser>>();
+            services.AddScoped<UserManager<TUser>>();
+            return services;
+        }
+
+        public static ServiceCollection AddEntity<TUser, TContext>(this ServiceCollection services)
+            where TUser : User where TContext : DbContext
+        {
+            services.AddEntity<TUser>();
+            services.AddScoped<DbContext, TContext>();
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Identity.Entity/IdentitySqlContext.cs
+++ b/src/Microsoft.AspNet.Identity.Entity/IdentitySqlContext.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.SqlServer;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.AspNet.Identity.Entity
@@ -33,7 +30,7 @@ namespace Microsoft.AspNet.Identity.Entity
         protected override void OnConfiguring(DbContextOptions builder)
         {
             // TODO: pull connection string from config
-            builder.UseSqlServer(@"Server=(localdb)\v11.0;Database=SimpleIdentity5;Trusted_Connection=True;");
+            builder.UseSqlServer(@"Server=(localdb)\v11.0;Database=SimpleIdentity;Trusted_Connection=True;");
         }
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/src/Microsoft.AspNet.Identity.Security/SecurityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Identity.Security/SecurityServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Identity.Security;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public static class SecurityServiceCollectionExtensions
+    {
+        public static ServiceCollection AddSecurity<TUser>(this ServiceCollection services)
+            where TUser : class
+        {
+            services.AddTransient<SignInManager<TUser>>();
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Framework.DependencyInjection
 {
     public static class IdentityServiceCollectionExtensions
     {
-        public static ServiceCollection AddIdentity<TUser, TRole>(this ServiceCollection services, Action<IdentityBuilder<TUser, TRole>> actionBuilder)
+        public static ServiceCollection AddIdentity<TUser, TRole>(this ServiceCollection services)
             where TUser : class
             where TRole : class
         {
@@ -16,8 +16,22 @@ namespace Microsoft.Framework.DependencyInjection
             services.Add(IdentityServices.GetDefaultRoleServices<TRole>());
             services.AddTransient<IOptionsSetup<IdentityOptions>, IdentityOptionsSetup>();
             services.AddSingleton<IOptionsAccessor<IdentityOptions>, OptionsAccessor<IdentityOptions>>();
+            return services;
+        }
+
+        public static ServiceCollection AddIdentity<TUser, TRole>(this ServiceCollection services, Action<IdentityBuilder<TUser, TRole>> actionBuilder)
+            where TUser : class
+            where TRole : class
+        {
+            services.AddIdentity<TUser, TRole>();
             actionBuilder(new IdentityBuilder<TUser, TRole>(services));
             return services;
+        }
+
+        public static ServiceCollection AddIdentity<TUser>(this ServiceCollection services)
+            where TUser : class
+        {
+            return services.AddIdentity<TUser, IdentityRole>();
         }
 
         public static ServiceCollection AddIdentity<TUser>(this ServiceCollection services, Action<IdentityBuilder<TUser, IdentityRole>> actionBuilder)


### PR DESCRIPTION
Enables the following:

```
        services.AddIdentity<ApplicationUser>().AddEntity<ApplicationUser, ApplicationDbContext>().AddSecurity<ApplicationUser>();
```
