### PR TITLE
Remove navigation properties

### DIFF
--- a/src/Microsoft.AspNet.Identity/IdentityUser.cs
+++ b/src/Microsoft.AspNet.Identity/IdentityUser.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Identity
 {
@@ -86,20 +85,5 @@ namespace Microsoft.AspNet.Identity
         ///     Used to record failures for the purposes of lockout
         /// </summary>
         public virtual int AccessFailedCount { get; set; }
-
-        /// <summary>
-        ///     Roles for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserRole<TKey>> Roles { get; } = new List<IdentityUserRole<TKey>>();
-
-        /// <summary>
-        ///     Claims for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserClaim<TKey>> Claims { get; } = new List<IdentityUserClaim<TKey>>();
-
-        /// <summary>
-        ///     Associated logins for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserLogin<TKey>> Logins { get; } = new List<IdentityUserLogin<TKey>>();
     }
 }

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/HttpSignInTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/HttpSignInTest.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.Identity.InMemory.Test
 {
-    public class ApplicationUser : IdentityUser { }
+    public class ApplicationUser : InMemoryUser { }
 
     public class HttpSignInTest
     {

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
@@ -6,7 +6,7 @@ using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Identity.InMemory.Test
 {
-    public class InMemoryStoreTest : UserManagerTestBase<IdentityUser, IdentityRole>
+    public class InMemoryStoreTest : UserManagerTestBase<InMemoryUser, IdentityRole>
     {
         protected override object CreateTestContext()
         {
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Identity.InMemory.Test
 
         protected override void AddUserStore(IServiceCollection services, object context = null)
         {
-            services.AddSingleton<IUserStore<IdentityUser>, InMemoryUserStore<IdentityUser>>();
+            services.AddSingleton<IUserStore<InMemoryUser>, InMemoryUserStore<InMemoryUser>>();
         }
 
         protected override void AddRoleStore(IServiceCollection services, object context = null)

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
@@ -10,6 +10,30 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Identity.InMemory
 {
+    public class InMemoryUser : IdentityUser
+    {
+        public InMemoryUser() { }
+
+        public InMemoryUser(string userName) : base(userName) { }
+
+
+        /// <summary>
+        ///     Roles for the user
+        /// </summary>
+        public virtual ICollection<IdentityUserRole> Roles { get; } = new List<IdentityUserRole>();
+
+        /// <summary>
+        ///     Claims for the user
+        /// </summary>
+        public virtual ICollection<IdentityUserClaim> Claims { get; } = new List<IdentityUserClaim>();
+
+        /// <summary>
+        ///     Associated logins for the user
+        /// </summary>
+        public virtual ICollection<IdentityUserLogin> Logins { get; } = new List<IdentityUserLogin>();
+
+    }
+
     public class InMemoryUserStore<TUser> :
         IUserLoginStore<TUser>,
         IUserRoleStore<TUser>,
@@ -21,7 +45,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         IUserPhoneNumberStore<TUser>,
         IQueryableUserStore<TUser>,
         IUserTwoFactorStore<TUser>
-        where TUser : IdentityUser
+        where TUser : InMemoryUser
     {
         private readonly Dictionary<string, TUser> _logins = new Dictionary<string, TUser>();
 
@@ -42,7 +66,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         {
             foreach (var claim in claims)
             {
-                user.Claims.Add(new IdentityUserClaim<string> { ClaimType = claim.Type, ClaimValue = claim.Value, UserId = user.Id });
+                user.Claims.Add(new IdentityUserClaim { ClaimType = claim.Type, ClaimValue = claim.Value, UserId = user.Id });
             }
             return Task.FromResult(0);
         }
@@ -149,7 +173,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         public virtual Task AddLoginAsync(TUser user, UserLoginInfo login,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            user.Logins.Add(new IdentityUserLogin<string>
+            user.Logins.Add(new IdentityUserLogin
             {
                 UserId = user.Id,
                 ProviderKey = login.ProviderKey,
@@ -292,7 +316,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         // RoleId == roleName for InMemory
         public Task AddToRoleAsync(TUser user, string role, CancellationToken cancellationToken = default(CancellationToken))
         {
-            user.Roles.Add(new IdentityUserRole<string> { RoleId = role, UserId = user.Id });
+            user.Roles.Add(new IdentityUserRole { RoleId = role, UserId = user.Id });
             return Task.FromResult(0);
         }
 


### PR DESCRIPTION
InMemory test was the only one left using them, moved to a specific user
subclass which had them for that test project

Fixes https://github.com/aspnet/Identity/issues/310

cc @divega @suhasj 