### PR TITLE
Swtiched logging from file to inmemory

### DIFF
--- a/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/InMemoryEFUserStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/InMemoryEFUserStoreTest.cs
@@ -7,7 +7,7 @@ using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
 {
-    public class InMemoryEFUserStoreTest : UserManagerTestBase<IdentityUser, IdentityRole>,IDisposable
+    public class InMemoryEFUserStoreTest : UserManagerTestBase<IdentityUser, IdentityRole>
     {
         protected override object CreateTestContext()
         {
@@ -23,11 +23,6 @@ namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
         {
             var store = new RoleStore<IdentityRole, InMemoryContext>((InMemoryContext)context);
             services.AddInstance<IRoleStore<IdentityRole>>(store);
-        }
-
-        public void Dispose()
-        {
-            loggerFactory.Dispose();
         }
     }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/SqlStoreTestBase.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/SqlStoreTestBase.cs
@@ -34,7 +34,6 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         public void DropDatabaseDone()
         {
             DropDb();
-            loggerFactory.Dispose();
         }
 
         public void DropDb()

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
@@ -7,7 +7,7 @@ using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Identity.InMemory.Test
 {
-    public class InMemoryStoreTest : UserManagerTestBase<InMemoryUser, IdentityRole>, IDisposable
+    public class InMemoryStoreTest : UserManagerTestBase<InMemoryUser, IdentityRole>
     {
         protected override object CreateTestContext()
         {
@@ -22,11 +22,6 @@ namespace Microsoft.AspNet.Identity.InMemory.Test
         protected override void AddRoleStore(IServiceCollection services, object context = null)
         {
             services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore<IdentityRole>>();
-        }
-
-        public void Dispose()
-        {
-            loggerFactory.Dispose();
         }
     }
 }

--- a/test/Shared/IdentityResultAssert.cs
+++ b/test/Shared/IdentityResultAssert.cs
@@ -59,12 +59,11 @@ namespace Microsoft.AspNet.Identity.Test
         }
         private static void VerifySuccessLog(ILogger logger, string className, string methodName, string id, string userOrRole = "user")
         {
-            if (logger is TestLogger)
+            TestLogger testlogger;
+            if ((testlogger = logger as TestLogger) != null)
             {
-                var fileLogger = logger as TestLogger;
                 string expected = string.Format("{0} for {1}: {2} : Success", methodName, userOrRole, id);
-
-                Assert.True(fileLogger.LogMessages.Contains(expected));
+                Assert.True(testlogger.LogMessages.Contains(expected));
             }
             else
             {
@@ -74,10 +73,10 @@ namespace Microsoft.AspNet.Identity.Test
 
         public static void VerifyLogMessage(ILogger logger, string expectedLog)
         {
-            if (logger is TestLogger)
+            TestLogger testlogger;
+            if ((testlogger = logger as TestLogger) != null)
             {
-                var fileLogger = logger as TestLogger;
-                Assert.True(fileLogger.LogMessages.Contains(expectedLog));
+                Assert.True(testlogger.LogMessages.Contains(expectedLog));
             }
             else
             {
@@ -87,13 +86,13 @@ namespace Microsoft.AspNet.Identity.Test
 
         private static void VerifyFailureLog(ILogger logger, string className, string methodName, string userId, string userOrRole = "user", params IdentityError[] errors)
         {
-            if (logger is TestLogger)
+            TestLogger testlogger;
+            if ((testlogger = logger as TestLogger) != null)
             {
-                var fileLogger = logger as TestLogger;
                 errors = errors ?? new IdentityError[] { new IdentityError() };
                 string expected = string.Format("{0} for {1}: {2} : Failed : {3}", methodName, userOrRole, userId, string.Join(",", errors.Select(x => x.Code).ToList()));
 
-                Assert.True(fileLogger.LogMessages.Contains(expected));
+                Assert.True(testlogger.LogMessages.Contains(expected));
             }
             else
             {

--- a/test/Shared/IdentityResultAssert.cs
+++ b/test/Shared/IdentityResultAssert.cs
@@ -60,14 +60,14 @@ namespace Microsoft.AspNet.Identity.Test
         }
         private static void VerifySuccessLog(ILogger logger, string className, string methodName, string id, string userOrRole = "user")
         {
-            if (logger is TestFileLogger)
+            if (logger is TestLogger)
             {
-                var fileLogger = logger as TestFileLogger;
+                var fileLogger = logger as TestLogger;
                 string expected = string.Format("{0} for {1}: {2} : Success", methodName, userOrRole, id);
 
-                lock (TestFileLogger.FileLock)
+                lock (TestLogger.FileLock)
                 {
-                    Assert.True(File.ReadAllText(fileLogger.FileName).Contains(expected)); 
+                    Assert.True(fileLogger.LogMessages.Contains(expected));
                 }
             }
             else
@@ -78,12 +78,12 @@ namespace Microsoft.AspNet.Identity.Test
 
         public static void VerifyLogMessage(ILogger logger, string expectedLog)
         {
-            if (logger is TestFileLogger)
+            if (logger is TestLogger)
             {
-                var fileLogger = logger as TestFileLogger;
-                lock (TestFileLogger.FileLock)
+                var fileLogger = logger as TestLogger;
+                lock (TestLogger.FileLock)
                 {
-                    Assert.True(File.ReadAllText(fileLogger.FileName).Contains(expectedLog));
+                    Assert.True(fileLogger.LogMessages.Contains(expectedLog));
                 }
             }
             else
@@ -94,15 +94,15 @@ namespace Microsoft.AspNet.Identity.Test
 
         private static void VerifyFailureLog(ILogger logger, string className, string methodName, string userId, string userOrRole = "user", params IdentityError[] errors)
         {
-            if (logger is TestFileLogger)
+            if (logger is TestLogger)
             {
-                var fileLogger = logger as TestFileLogger;
+                var fileLogger = logger as TestLogger;
                 errors = errors ?? new IdentityError[] { new IdentityError() };
                 string expected = string.Format("{0} for {1}: {2} : Failed : {3}", methodName, userOrRole, userId, string.Join(",", errors.Select(x => x.Code).ToList()));
 
-                lock (TestFileLogger.FileLock)
+                lock (TestLogger.FileLock)
                 {
-                    Assert.True(File.ReadAllText(fileLogger.FileName).Contains(expected));
+                    Assert.True(fileLogger.LogMessages.Contains(expected));
                 }
             }
             else

--- a/test/Shared/IdentityResultAssert.cs
+++ b/test/Shared/IdentityResultAssert.cs
@@ -64,10 +64,7 @@ namespace Microsoft.AspNet.Identity.Test
                 var fileLogger = logger as TestLogger;
                 string expected = string.Format("{0} for {1}: {2} : Success", methodName, userOrRole, id);
 
-                lock (TestLogger.Lock)
-                {
-                    Assert.True(fileLogger.LogMessages.Contains(expected));
-                }
+                Assert.True(fileLogger.LogMessages.Contains(expected));
             }
             else
             {
@@ -80,10 +77,7 @@ namespace Microsoft.AspNet.Identity.Test
             if (logger is TestLogger)
             {
                 var fileLogger = logger as TestLogger;
-                lock (TestLogger.Lock)
-                {
-                    Assert.True(fileLogger.LogMessages.Contains(expectedLog));
-                }
+                Assert.True(fileLogger.LogMessages.Contains(expectedLog));
             }
             else
             {
@@ -99,10 +93,7 @@ namespace Microsoft.AspNet.Identity.Test
                 errors = errors ?? new IdentityError[] { new IdentityError() };
                 string expected = string.Format("{0} for {1}: {2} : Failed : {3}", methodName, userOrRole, userId, string.Join(",", errors.Select(x => x.Code).ToList()));
 
-                lock (TestLogger.Lock)
-                {
-                    Assert.True(fileLogger.LogMessages.Contains(expected));
-                }
+                Assert.True(fileLogger.LogMessages.Contains(expected));
             }
             else
             {

--- a/test/Shared/IdentityResultAssert.cs
+++ b/test/Shared/IdentityResultAssert.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
 using System.Linq;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -65,7 +64,7 @@ namespace Microsoft.AspNet.Identity.Test
                 var fileLogger = logger as TestLogger;
                 string expected = string.Format("{0} for {1}: {2} : Success", methodName, userOrRole, id);
 
-                lock (TestLogger.FileLock)
+                lock (TestLogger.Lock)
                 {
                     Assert.True(fileLogger.LogMessages.Contains(expected));
                 }
@@ -81,7 +80,7 @@ namespace Microsoft.AspNet.Identity.Test
             if (logger is TestLogger)
             {
                 var fileLogger = logger as TestLogger;
-                lock (TestLogger.FileLock)
+                lock (TestLogger.Lock)
                 {
                     Assert.True(fileLogger.LogMessages.Contains(expectedLog));
                 }
@@ -100,7 +99,7 @@ namespace Microsoft.AspNet.Identity.Test
                 errors = errors ?? new IdentityError[] { new IdentityError() };
                 string expected = string.Format("{0} for {1}: {2} : Failed : {3}", methodName, userOrRole, userId, string.Join(",", errors.Select(x => x.Code).ToList()));
 
-                lock (TestLogger.FileLock)
+                lock (TestLogger.Lock)
                 {
                     Assert.True(fileLogger.LogMessages.Contains(expected));
                 }

--- a/test/Shared/IdentityResultAssert.cs
+++ b/test/Shared/IdentityResultAssert.cs
@@ -59,8 +59,8 @@ namespace Microsoft.AspNet.Identity.Test
         }
         private static void VerifySuccessLog(ILogger logger, string className, string methodName, string id, string userOrRole = "user")
         {
-            TestLogger testlogger;
-            if ((testlogger = logger as TestLogger) != null)
+            TestLogger testlogger = logger as TestLogger;
+            if (testlogger != null)
             {
                 string expected = string.Format("{0} for {1}: {2} : Success", methodName, userOrRole, id);
                 Assert.True(testlogger.LogMessages.Contains(expected));
@@ -73,8 +73,8 @@ namespace Microsoft.AspNet.Identity.Test
 
         public static void VerifyLogMessage(ILogger logger, string expectedLog)
         {
-            TestLogger testlogger;
-            if ((testlogger = logger as TestLogger) != null)
+            TestLogger testlogger = logger as TestLogger;
+            if (testlogger != null)
             {
                 Assert.True(testlogger.LogMessages.Contains(expectedLog));
             }
@@ -86,8 +86,8 @@ namespace Microsoft.AspNet.Identity.Test
 
         private static void VerifyFailureLog(ILogger logger, string className, string methodName, string userId, string userOrRole = "user", params IdentityError[] errors)
         {
-            TestLogger testlogger;
-            if ((testlogger = logger as TestLogger) != null)
+            TestLogger testlogger = logger as TestLogger;
+            if (testlogger != null)
             {
                 errors = errors ?? new IdentityError[] { new IdentityError() };
                 string expected = string.Format("{0} for {1}: {2} : Failed : {3}", methodName, userOrRole, userId, string.Join(",", errors.Select(x => x.Code).ToList()));

--- a/test/Shared/TestFileLogger.cs
+++ b/test/Shared/TestFileLogger.cs
@@ -4,27 +4,19 @@
 using System;
 using System.IO;
 using Microsoft.Framework.Logging;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Identity.Test
 {
-    public class TestFileLogger : ILogger
+    public class TestLogger : ILogger
     {
-        public string FileName { get; set; }
-
         public static object FileLock { get; private set; } = new object();
 
-        public TestFileLogger(string name)
+        public IList<string> LogMessages { get; private set; } = new List<string>();
+
+        public TestLogger(string name)
         {
-            var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "IdentityTests");
-            Directory.CreateDirectory(directory);
-            FileName = Path.Combine(directory, (name + DateTime.Now.Ticks + "log.txt"));
-            lock (FileLock)
-            {
-                if (!File.Exists(FileName))
-                {
-                    File.Create(FileName).Close();
-                } 
-            }
+            
         }
 
         public IDisposable BeginScope(object state)
@@ -41,7 +33,7 @@ namespace Microsoft.AspNet.Identity.Test
         {
             lock (FileLock)
             {
-                File.AppendAllLines(FileName, new string[] { state.ToString() });
+                LogMessages.Add(state.ToString());
             }
         }
     }

--- a/test/Shared/TestFileLoggerFactory.cs
+++ b/test/Shared/TestFileLoggerFactory.cs
@@ -9,15 +9,8 @@ using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Identity.Test
 {
-    public class TestFileLoggerFactory : ILoggerFactory, IDisposable
+    public class TestLoggerFactory : ILoggerFactory
     {
-        private static Dictionary<string, ILogger> _loggers;
-
-        static TestFileLoggerFactory()
-        {
-            _loggers = new Dictionary<string, ILogger>();
-        }
-
         public void AddProvider(ILoggerProvider provider)
         {
 
@@ -25,31 +18,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         public ILogger Create(string name)
         {
-            if (!_loggers.ContainsKey(name))
-            {
-                try
-                {
-                    _loggers.Add(name, new TestFileLogger(name));
-                }
-                catch (ArgumentException ex)
-                {
-                    // Silently skip if there is already a logger with that key
-                }
-            }
-
-            return _loggers[name];
-        }
-
-        public void Dispose()
-        {
-            Parallel.ForEach(_loggers.Values, l =>
-            {
-                if(l is TestFileLogger)
-                {
-                    var logger = l as TestFileLogger;
-                    File.Delete(logger.FileName);
-                }
-            });
+            return new TestLogger(name);
         }
     } 
 }

--- a/test/Shared/TestLogger.cs
+++ b/test/Shared/TestLogger.cs
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using Microsoft.Framework.Logging;
 using System.Collections.Generic;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Identity.Test
 {
     public class TestLogger : ILogger
     {
-        public static object FileLock { get; private set; } = new object();
+        public static object Lock { get; private set; } = new object();
 
         public IList<string> LogMessages { get; private set; } = new List<string>();
 
@@ -31,7 +30,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         public void Write(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
         {
-            lock (FileLock)
+            lock (Lock)
             {
                 LogMessages.Add(state.ToString());
             }

--- a/test/Shared/TestLogger.cs
+++ b/test/Shared/TestLogger.cs
@@ -11,11 +11,6 @@ namespace Microsoft.AspNet.Identity.Test
     {
         public IList<string> LogMessages { get; private set; } = new List<string>();
 
-        public TestLogger(string name)
-        {
-
-        }
-
         public IDisposable BeginScope(object state)
         {
             throw new NotImplementedException();

--- a/test/Shared/TestLogger.cs
+++ b/test/Shared/TestLogger.cs
@@ -9,13 +9,11 @@ namespace Microsoft.AspNet.Identity.Test
 {
     public class TestLogger : ILogger
     {
-        public static object Lock { get; private set; } = new object();
-
         public IList<string> LogMessages { get; private set; } = new List<string>();
 
         public TestLogger(string name)
         {
-            
+
         }
 
         public IDisposable BeginScope(object state)
@@ -30,10 +28,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         public void Write(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
         {
-            lock (Lock)
-            {
-                LogMessages.Add(state.ToString());
-            }
+            LogMessages.Add(state.ToString());
         }
     }
 }

--- a/test/Shared/TestLoggerFactory.cs
+++ b/test/Shared/TestLoggerFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.IO;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Identity.Test

--- a/test/Shared/TestLoggerFactory.cs
+++ b/test/Shared/TestLoggerFactory.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.AspNet.Identity.Test
@@ -17,7 +14,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         public ILogger Create(string name)
         {
-            return new TestLogger(name);
+            return new TestLogger();
         }
     } 
 }

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -26,11 +26,11 @@ namespace Microsoft.AspNet.Identity.Test
         where TRole : IdentityRole<TKey>, new()
         where TKey : IEquatable<TKey>
     {
-        protected TestFileLoggerFactory loggerFactory;
+        protected TestLoggerFactory loggerFactory;
 
         public UserManagerTestBase()
         {
-            loggerFactory = new TestFileLoggerFactory();
+            loggerFactory = new TestLoggerFactory();
         }
 
         protected virtual void SetupIdentityServices(IServiceCollection services, object context = null)


### PR DESCRIPTION
@HaoK @divega 

I switched from logging the messages in memory from writing it to a file since the this was causing the tests to be flaky