### PR TITLE
Moved POCOs to EF and fixed tests

### DIFF
--- a/samples/IdentitySample.Mvc/Models/SampleData.cs
+++ b/samples/IdentitySample.Mvc/Models/SampleData.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.Data.Entity.SqlServer;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.OptionsModel;

--- a/samples/IdentitySample.Mvc/Startup.cs
+++ b/samples/IdentitySample.Mvc/Startup.cs
@@ -2,6 +2,7 @@ using IdentitySample.Models;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Diagnostics;
 using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -31,31 +31,31 @@ namespace Microsoft.AspNet.Identity.EntityFramework
                     b.Key(u => u.Id);
                     b.ForRelational().Table("AspNetUsers");
                     b.Property(u => u.ConcurrencyStamp).ConcurrencyToken();
-                    b.HasMany(x => x.Roles).WithOne().ForeignKey(x=>x.UserId);
-                    b.HasMany(x => x.Claims).WithOne().ForeignKey(x=>x.UserId);
-                    b.HasMany(x => x.Logins).WithOne().ForeignKey(x=>x.UserId);
+
+                    b.Collection(u => u.Claims).InverseReference().ForeignKey(uc => uc.UserId);
+                    b.Collection(u => u.Logins).InverseReference().ForeignKey(ul => ul.UserId);
+                    b.Collection(u => u.Roles).InverseReference().ForeignKey(ur => ur.UserId);
                 });
 
             builder.Entity<TRole>(b =>
                 {
                     b.Key(r => r.Id);
                     b.ForRelational().Table("AspNetRoles");
-                    b.HasMany(x => x.Claims).WithOne().ForeignKey(x => x.RoleId);
-                    b.HasMany(x => x.Users).WithOne().ForeignKey(x => x.RoleId);
                     b.Property(r => r.ConcurrencyStamp).ConcurrencyToken();
+
+                    b.Collection(r => r.Users).InverseReference().ForeignKey(ur => ur.RoleId);
+                    b.Collection(r => r.Claims).InverseReference().ForeignKey(rc => rc.RoleId);
                 });
 
             builder.Entity<IdentityUserClaim<TKey>>(b =>
                 {
                     b.Key(uc => uc.Id);
-                    b.Reference<TUser>().InverseCollection().ForeignKey(uc => uc.UserId);
-		    b.ForRelational().Table("AspNetUserClaims");
+                    b.ForRelational().Table("AspNetUserClaims");
                 });
 
             builder.Entity<IdentityRoleClaim<TKey>>(b =>
                 {
                     b.Key(rc => rc.Id);
-                    b.Reference<TRole>().InverseCollection().ForeignKey(rc => rc.RoleId);
                     b.ForRelational().Table("AspNetRoleClaims");
                 });
 
@@ -71,7 +71,6 @@ namespace Microsoft.AspNet.Identity.EntityFramework
             builder.Entity<IdentityUserLogin<TKey>>(b =>
                 {
                     b.Key(l => new { l.LoginProvider, l.ProviderKey });
-                    b.Reference<TUser>().InverseCollection().ForeignKey(uc => uc.UserId);
                     b.ForRelational().Table("AspNetUserLogins");
                 });
         }

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -31,12 +31,17 @@ namespace Microsoft.AspNet.Identity.EntityFramework
                     b.Key(u => u.Id);
                     b.ForRelational().Table("AspNetUsers");
                     b.Property(u => u.ConcurrencyStamp).ConcurrencyToken();
+                    b.HasMany(x => x.Roles).WithOne().ForeignKey(x=>x.UserId);
+                    b.HasMany(x => x.Claims).WithOne().ForeignKey(x=>x.UserId);
+                    b.HasMany(x => x.Logins).WithOne().ForeignKey(x=>x.UserId);
                 });
 
             builder.Entity<TRole>(b =>
                 {
                     b.Key(r => r.Id);
                     b.ForRelational().Table("AspNetRoles");
+                    b.HasMany(x => x.Claims).WithOne().ForeignKey(x => x.RoleId);
+                    b.HasMany(x => x.Users).WithOne().ForeignKey(x => x.RoleId);
                     b.Property(r => r.ConcurrencyStamp).ConcurrencyToken();
                 });
 
@@ -44,7 +49,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
                 {
                     b.Key(uc => uc.Id);
                     b.Reference<TUser>().InverseCollection().ForeignKey(uc => uc.UserId);
-                    b.ForRelational().Table("AspNetUserClaims");
+		    b.ForRelational().Table("AspNetUserClaims");
                 });
 
             builder.Entity<IdentityRoleClaim<TKey>>(b =>

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRole.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRole.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.EntityFramework
 {
     /// <summary>
     ///     Represents a Role entity
@@ -49,12 +49,12 @@ namespace Microsoft.AspNet.Identity
         /// <summary>
         ///     Navigation property for users in the role
         /// </summary>
-        public virtual ICollection<IdentityUserRole<TKey>> Users { get; private set; } = new List<IdentityUserRole<TKey>>();
+        public virtual ICollection<IdentityUserRole<TKey>> Users { get; set; } = new List<IdentityUserRole<TKey>>();
 
         /// <summary>
         ///     Navigation property for claims in the role
         /// </summary>
-        public virtual ICollection<IdentityRoleClaim<TKey>> Claims { get; private set; } = new List<IdentityRoleClaim<TKey>>();
+        public virtual ICollection<IdentityRoleClaim<TKey>> Claims { get; set; } = new List<IdentityRoleClaim<TKey>>();
 
         /// <summary>
         ///     Role id

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRole.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRole.cs
@@ -49,12 +49,12 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         /// <summary>
         ///     Navigation property for users in the role
         /// </summary>
-        public virtual ICollection<IdentityUserRole<TKey>> Users { get; set; } = new List<IdentityUserRole<TKey>>();
+        public virtual ICollection<IdentityUserRole<TKey>> Users { get; } = new List<IdentityUserRole<TKey>>();
 
         /// <summary>
         ///     Navigation property for claims in the role
         /// </summary>
-        public virtual ICollection<IdentityRoleClaim<TKey>> Claims { get; set; } = new List<IdentityRoleClaim<TKey>>();
+        public virtual ICollection<IdentityRoleClaim<TKey>> Claims { get; } = new List<IdentityRoleClaim<TKey>>();
 
         /// <summary>
         ///     Role id

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRoleClaim.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityRoleClaim.cs
@@ -3,15 +3,15 @@
 
 using System;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.EntityFramework
 {
-    public class IdentityUserClaim : IdentityUserClaim<string> { }
+    public class IdentityRoleClaim : IdentityRoleClaim<string> { }
 
     /// <summary>
-    ///     EntityType that represents one specific user claim
+    ///     EntityType that represents one specific role claim
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
-    public class IdentityUserClaim<TKey> where TKey : IEquatable<TKey>
+    public class IdentityRoleClaim<TKey> where TKey : IEquatable<TKey>
     {
         /// <summary>
         ///     Primary key
@@ -19,9 +19,9 @@ namespace Microsoft.AspNet.Identity
         public virtual int Id { get; set; }
 
         /// <summary>
-        ///     User Id for the user who owns this claim
+        ///     User Id for the role this claim belongs to
         /// </summary>
-        public virtual TKey UserId { get; set; }
+        public virtual TKey RoleId { get; set; }
 
         /// <summary>
         ///     Claim type

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUser.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUser.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.EntityFramework
 {
     public class IdentityUser : IdentityUser<string>
     {
@@ -87,5 +88,20 @@ namespace Microsoft.AspNet.Identity
         ///     Used to record failures for the purposes of lockout
         /// </summary>
         public virtual int AccessFailedCount { get; set; }
+
+        /// <summary>
+        ///     Navigation property for users in the role
+        /// </summary>
+        public virtual ICollection<IdentityUserRole<TKey>> Roles { get; set; } = new List<IdentityUserRole<TKey>>();
+
+        /// <summary>
+        ///     Navigation property for users claims
+        /// </summary>
+        public virtual ICollection<IdentityUserClaim<TKey>> Claims { get; set; } = new List<IdentityUserClaim<TKey>>();
+
+        /// <summary>
+        ///     Navigation property for users logins
+        /// </summary>
+        public virtual ICollection<IdentityUserLogin<TKey>> Logins { get; set; } = new List<IdentityUserLogin<TKey>>();
     }
 }

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUser.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUser.cs
@@ -92,16 +92,16 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         /// <summary>
         ///     Navigation property for users in the role
         /// </summary>
-        public virtual ICollection<IdentityUserRole<TKey>> Roles { get; set; } = new List<IdentityUserRole<TKey>>();
+        public virtual ICollection<IdentityUserRole<TKey>> Roles { get; } = new List<IdentityUserRole<TKey>>();
 
         /// <summary>
         ///     Navigation property for users claims
         /// </summary>
-        public virtual ICollection<IdentityUserClaim<TKey>> Claims { get; set; } = new List<IdentityUserClaim<TKey>>();
+        public virtual ICollection<IdentityUserClaim<TKey>> Claims { get; } = new List<IdentityUserClaim<TKey>>();
 
         /// <summary>
         ///     Navigation property for users logins
         /// </summary>
-        public virtual ICollection<IdentityUserLogin<TKey>> Logins { get; set; } = new List<IdentityUserLogin<TKey>>();
+        public virtual ICollection<IdentityUserLogin<TKey>> Logins { get; } = new List<IdentityUserLogin<TKey>>();
     }
 }

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserClaim.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserClaim.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Identity.EntityFramework
+{
+    public class IdentityUserClaim : IdentityUserClaim<string> { }
+
+    /// <summary>
+    ///     EntityType that represents one specific user claim
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public class IdentityUserClaim<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        ///     Primary key
+        /// </summary>
+        public virtual int Id { get; set; }
+
+        /// <summary>
+        ///     User Id for the user who owns this claim
+        /// </summary>
+        public virtual TKey UserId { get; set; }
+
+        /// <summary>
+        ///     Claim type
+        /// </summary>
+        public virtual string ClaimType { get; set; }
+
+        /// <summary>
+        ///     Claim value
+        /// </summary>
+        public virtual string ClaimValue { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserLogin.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserLogin.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.EntityFramework
 {
     public class IdentityUserLogin : IdentityUserLogin<string> { }
 

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserRole.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityUserRole.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Identity.EntityFramework
+{
+    public class IdentityUserRole : IdentityUserRole<string> { }
+
+    /// <summary>
+    ///     EntityType that represents a user belonging to a role
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public class IdentityUserRole<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        ///     UserId for the user that is in the role
+        /// </summary>
+        public virtual TKey UserId { get; set; }
+
+        /// <summary>
+        ///     RoleId for the role
+        /// </summary>
+        public virtual TKey RoleId { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Framework.DependencyInjection
             return services.Configure<CookieAuthenticationOptions>(configureOptions, IdentityOptions.ApplicationCookieAuthenticationScheme);
         }
 
-        public static IdentityBuilder AddIdentity(this IServiceCollection services)
-        {
-            return services.AddIdentity<IdentityUser, IdentityRole>(configureOptions: null);
-        }
-
         public static IdentityBuilder AddIdentity<TUser, TRole>(
             this IServiceCollection services)
             where TUser : class

--- a/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/InMemoryEFUserStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/InMemoryEFUserStoreTest.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using Microsoft.AspNet.Identity.Test;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
 {
-    public class InMemoryEFUserStoreTest : UserManagerTestBase<IdentityUser, IdentityRole>
+    public class InMemoryEFUserStoreTest : UserManagerTestBase<IdentityUser, IdentityRole, string>
     {
         protected override object CreateTestContext()
         {
@@ -24,5 +25,37 @@ namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
             var store = new RoleStore<IdentityRole, InMemoryContext>((InMemoryContext)context);
             services.AddInstance<IRoleStore<IdentityRole>>(store);
         }
+
+        protected override IdentityUser CreateTestUser(string namePrefix = "", string email = "", string phoneNumber = "",
+            bool lockoutEnabled = false, DateTimeOffset? lockoutEnd = default(DateTimeOffset?), bool useNamePrefixAsUserName = false)
+        {
+            return new IdentityUser
+            {
+                UserName = useNamePrefixAsUserName ? namePrefix : string.Format("{0}{1}", namePrefix, Guid.NewGuid()),
+                Email = email,
+                PhoneNumber = phoneNumber,
+                LockoutEnabled = lockoutEnabled,
+                LockoutEnd = lockoutEnd
+            };
+        }
+
+        protected override IdentityRole CreateTestRole(string roleNamePrefix = "", bool useRoleNamePrefixAsRoleName = false)
+        {
+            var roleName = useRoleNamePrefixAsRoleName ? roleNamePrefix : string.Format("{0}{1}", roleNamePrefix, Guid.NewGuid());
+            return new IdentityRole(roleName);
+        }
+
+        protected override void SetUserPasswordHash(IdentityUser user, string hashedPassword)
+        {
+            user.PasswordHash = hashedPassword;
+        }
+
+        protected override Expression<Func<IdentityUser, bool>> UserNameEqualsPredicate(string userName) => u => u.UserName == userName;
+
+        protected override Expression<Func<IdentityRole, bool>> RoleNameEqualsPredicate(string roleName) => r => r.Name == roleName;
+
+        protected override Expression<Func<IdentityUser, bool>> UserNameStartsWithPredicate(string userName) => u => u.UserName.StartsWith(userName);
+
+        protected override Expression<Func<IdentityRole, bool>> RoleNameStartsWithPredicate(string roleName) => r => r.Name.StartsWith(roleName);
     }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/RoleStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/RoleStoreTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
             services.AddEntityFramework().AddInMemoryStore();
             var store = new RoleStore<IdentityRole>(new InMemoryContext());
             services.AddInstance<IRoleStore<IdentityRole>>(store);
-            services.AddIdentity();
+            services.AddIdentity<IdentityUser,IdentityRole>();
             var provider = services.BuildServiceProvider();
             var manager = provider.GetRequiredService<RoleManager<IdentityRole>>();
             Assert.NotNull(manager);
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.InMemory.Test
             services.AddEntityFramework().AddInMemoryStore();
             services.AddTransient<InMemoryContext>();
             services.AddTransient<IRoleStore<IdentityRole>, RoleStore<IdentityRole, InMemoryContext>>();
-            services.AddIdentity();
+            services.AddIdentity<IdentityUser, IdentityRole>();
             services.AddSingleton<RoleManager<IdentityRole>>();
             var provider = services.BuildServiceProvider();
             var manager = provider.GetRequiredService<RoleManager<IdentityRole>>();

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/DefaultPocoTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/DefaultPocoTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Identity.Test;
@@ -14,7 +16,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
     [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public class DefaultPocoTest
     {
-        private readonly string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=DefaultSchemaTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;";
+        private readonly string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=DefaultSchemaTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;MultipleActiveResultSets=true";
         public IdentityDbContext CreateContext(bool ensureCreated = false)
         {
             var db = DbUtil.Create(ConnectionString);
@@ -60,6 +62,148 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             var user = new IdentityUser { UserName = userName };
             IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user, password));
             IdentityResultAssert.IsSuccess(await userManager.DeleteAsync(user));
+        }
+
+        [Fact]
+        public async Task CanIncludeUserClaimsTest()
+        {
+            // Arrange
+            CreateContext(true);
+            var builder = new ApplicationBuilder(CallContextServiceLocator.Locator.ServiceProvider);
+
+            var services = new ServiceCollection();
+            DbUtil.ConfigureDbServices<IdentityDbContext>(ConnectionString, services);
+            services.AddIdentity<IdentityUser, IdentityRole>().AddEntityFrameworkStores<IdentityDbContext>();
+            builder.ApplicationServices = services.BuildServiceProvider();
+
+            var userManager = builder.ApplicationServices.GetRequiredService<UserManager<IdentityUser>>();
+            var dbContext = builder.ApplicationServices.GetRequiredService<IdentityDbContext>();
+
+            var username = "user" + new Random().Next();
+            var user = new IdentityUser() { UserName = username };
+            IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user));
+
+            for (var i = 0; i < 10; i++)
+            {
+                IdentityResultAssert.IsSuccess(await userManager.AddClaimAsync(user, new Claim(i.ToString(), "foo")));
+            }
+
+            user = dbContext.Users.Include(x => x.Claims).FirstOrDefault(x => x.UserName == username);
+
+            // Assert
+            Assert.NotNull(user);
+            Assert.NotNull(user.Claims);
+            Assert.Equal(10, user.Claims.Count());
+        }
+
+        [Fact]
+        public async Task CanIncludeUserLoginsTest()
+        {
+            // Arrange
+            CreateContext(true);
+            var builder = new ApplicationBuilder(CallContextServiceLocator.Locator.ServiceProvider);
+
+            var services = new ServiceCollection();
+            DbUtil.ConfigureDbServices<IdentityDbContext>(ConnectionString, services);
+            services.AddIdentity<IdentityUser, IdentityRole>().AddEntityFrameworkStores<IdentityDbContext>();
+            builder.ApplicationServices = services.BuildServiceProvider();
+
+            var userManager = builder.ApplicationServices.GetRequiredService<UserManager<IdentityUser>>();
+            var dbContext = builder.ApplicationServices.GetRequiredService<IdentityDbContext>();
+
+            var username = "user" + new Random().Next();
+            var user = new IdentityUser() { UserName = username };
+            IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user));
+
+            for (var i = 0; i < 10; i++)
+            {
+                IdentityResultAssert.IsSuccess(await userManager.AddLoginAsync(user, new UserLoginInfo("foo" + i, "bar" + i, "foo")));
+            }
+
+            user = dbContext.Users.Include(x => x.Logins).FirstOrDefault(x => x.UserName == username);
+
+            // Assert
+            Assert.NotNull(user);
+            Assert.NotNull(user.Logins);
+            Assert.Equal(10, user.Logins.Count());
+        }
+
+        [Fact]
+        public async Task CanIncludeUserRolesTest()
+        {
+            // Arrange
+            CreateContext(true);
+            var builder = new ApplicationBuilder(CallContextServiceLocator.Locator.ServiceProvider);
+
+            var services = new ServiceCollection();
+            DbUtil.ConfigureDbServices<IdentityDbContext>(ConnectionString, services);
+            services.AddIdentity<IdentityUser, IdentityRole>().AddEntityFrameworkStores<IdentityDbContext>();
+            builder.ApplicationServices = services.BuildServiceProvider();
+
+            var userManager = builder.ApplicationServices.GetRequiredService<UserManager<IdentityUser>>();
+            var roleManager = builder.ApplicationServices.GetRequiredService<RoleManager<IdentityRole>>();
+            var dbContext = builder.ApplicationServices.GetRequiredService<IdentityDbContext>();
+
+            const string roleName = "Admin";
+            for (var i = 0; i < 10; i++)
+            {
+                IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(new IdentityRole(roleName + i)));
+            }
+            var username = "user" + new Random().Next();
+            var user = new IdentityUser() { UserName = username };
+            IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user));
+
+            for (var i = 0; i < 10; i++)
+            {
+                IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(user, roleName + i));
+            }
+
+            user = dbContext.Users.Include(x => x.Roles).FirstOrDefault(x => x.UserName == username);
+
+            // Assert
+            Assert.NotNull(user);
+            Assert.NotNull(user.Roles);
+            Assert.Equal(10, user.Roles.Count());
+
+            for (var i = 0; i < 10; i++)
+            {
+                var role = dbContext.Roles.Include(r => r.Users).FirstOrDefault(r => r.Name == (roleName + i));
+                Assert.NotNull(role);
+                Assert.NotNull(role.Users);
+                Assert.Equal(1, role.Users.Count());
+            }
+        }
+
+        [Fact]
+        public async Task CanIncludeRoleClaimsTest()
+        {
+            // Arrange
+            CreateContext(true);
+            var builder = new ApplicationBuilder(CallContextServiceLocator.Locator.ServiceProvider);
+
+            var services = new ServiceCollection();
+            DbUtil.ConfigureDbServices<IdentityDbContext>(ConnectionString, services);
+            services.AddIdentity<IdentityUser, IdentityRole>().AddEntityFrameworkStores<IdentityDbContext>();
+            builder.ApplicationServices = services.BuildServiceProvider();
+
+            var roleManager = builder.ApplicationServices.GetRequiredService<RoleManager<IdentityRole>>();
+            var dbContext = builder.ApplicationServices.GetRequiredService<IdentityDbContext>();
+
+            var role = new IdentityRole("Admin");
+
+            IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(role));
+
+            for (var i = 0; i < 10; i++)
+            {
+                IdentityResultAssert.IsSuccess(await roleManager.AddClaimAsync(role, new Claim("foo" + i, "bar" + i)));
+            }
+
+            role = dbContext.Roles.Include(x => x.Claims).FirstOrDefault(x => x.Name == "Admin");
+
+            // Assert
+            Assert.NotNull(role);
+            Assert.NotNull(role.Claims);
+            Assert.Equal(10, role.Claims.Count());
         }
 
         [TestPriority(10000)]

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using Microsoft.AspNet.Identity.Test;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreIntKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreIntKeyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreStringKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreStringKeyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/FunctionalTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/FunctionalTest.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNet.TestHost;
 using Microsoft.Framework.DependencyInjection;
 using Shouldly;
 using Xunit;
+using Microsoft.AspNet.Identity.Test;
 
 namespace Microsoft.AspNet.Identity.InMemory
 {
@@ -162,8 +163,8 @@ namespace Microsoft.AspNet.Identity.InMemory
                 {
                     var req = context.Request;
                     var res = context.Response;
-                    var userManager = context.RequestServices.GetRequiredService<UserManager<InMemoryUser>>();
-                    var signInManager = context.RequestServices.GetRequiredService<SignInManager<InMemoryUser>>();
+                    var userManager = context.RequestServices.GetRequiredService<UserManager<TestUser>>();
+                    var signInManager = context.RequestServices.GetRequiredService<SignInManager<TestUser>>();
                     PathString remainder;
                     if (req.Path == new PathString("/normal"))
                     {
@@ -171,7 +172,7 @@ namespace Microsoft.AspNet.Identity.InMemory
                     }
                     else if (req.Path == new PathString("/createMe"))
                     {
-                        var result = await userManager.CreateAsync(new InMemoryUser("hao"), TestPassword);
+                        var result = await userManager.CreateAsync(new TestUser("hao"), TestPassword);
                         res.StatusCode = result.Succeeded ? 200 : 500;
                     }
                     else if (req.Path == new PathString("/protected"))
@@ -220,9 +221,9 @@ namespace Microsoft.AspNet.Identity.InMemory
             },
             services =>
             {
-                services.AddIdentity<InMemoryUser, IdentityRole>();
-                services.AddSingleton<IUserStore<InMemoryUser>, InMemoryUserStore<InMemoryUser>>();
-                services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore<IdentityRole>>();
+                services.AddIdentity<TestUser, TestRole>();
+                services.AddSingleton<IUserStore<TestUser>, InMemoryUserStore<TestUser>>();
+                services.AddSingleton<IRoleStore<TestRole>, InMemoryRoleStore<TestRole>>();
                 services.ConfigureIdentityApplicationCookie(configureAppCookie);
             });
             server.BaseAddress = baseAddress;

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/HttpSignInTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/HttpSignInTest.cs
@@ -15,8 +15,6 @@ using Xunit;
 
 namespace Microsoft.AspNet.Identity.InMemory.Test
 {
-    public class ApplicationUser : InMemoryUser { }
-
     public class HttpSignInTest
     {
         [Theory]
@@ -37,19 +35,19 @@ namespace Microsoft.AspNet.Identity.InMemory.Test
             contextAccessor.Setup(a => a.HttpContext).Returns(context.Object);
             var services = new ServiceCollection();
             services.AddInstance(contextAccessor.Object);
-            services.AddIdentity<ApplicationUser, IdentityRole>();
-            services.AddSingleton<IUserStore<ApplicationUser>, InMemoryUserStore<ApplicationUser>>();
-            services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore<IdentityRole>>();
+            services.AddIdentity<TestUser, TestRole>();
+                services.AddSingleton<IUserStore<TestUser>, InMemoryUserStore<TestUser>>();
+                services.AddSingleton<IRoleStore<TestRole>, InMemoryRoleStore<TestRole>>();
             app.ApplicationServices = services.BuildServiceProvider();
 
             // Act
-            var user = new ApplicationUser
+            var user = new TestUser
             {
                 UserName = "Yolo"
             };
             const string password = "Yol0Sw@g!";
-            var userManager = app.ApplicationServices.GetRequiredService<UserManager<ApplicationUser>>();
-            var signInManager = app.ApplicationServices.GetRequiredService<SignInManager<ApplicationUser>>();
+            var userManager = app.ApplicationServices.GetRequiredService<UserManager<TestUser>>();
+            var signInManager = app.ApplicationServices.GetRequiredService<SignInManager<TestUser>>();
 
             IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user, password));
             var result = await signInManager.PasswordSignInAsync(user, password, isPersistent, false);

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryRoleStore.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryRoleStore.cs
@@ -7,10 +7,11 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Identity.Test;
 
 namespace Microsoft.AspNet.Identity.InMemory
 {
-    public class InMemoryRoleStore<TRole> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole> where TRole : IdentityRole
+    public class InMemoryRoleStore<TRole> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole> where TRole : TestRole
 
     {
         private readonly Dictionary<string, TRole> _roles = new Dictionary<string, TRole>();
@@ -81,7 +82,7 @@ namespace Microsoft.AspNet.Identity.InMemory
 
         public Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default(CancellationToken))
         {
-            role.Claims.Add(new IdentityRoleClaim<string> { ClaimType = claim.Type, ClaimValue = claim.Value, RoleId = role.Id });
+            role.Claims.Add(new TestRoleClaim<string> { ClaimType = claim.Type, ClaimValue = claim.Value, RoleId = role.Id });
             return Task.FromResult(0);
         }
 

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryStoreTest.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using Microsoft.AspNet.Identity.Test;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.AspNet.Identity.InMemory.Test
 {
-    public class InMemoryStoreTest : UserManagerTestBase<InMemoryUser, IdentityRole>
+    public class InMemoryStoreTest : UserManagerTestBase<TestUser, TestRole>
     {
         protected override object CreateTestContext()
         {
@@ -16,12 +17,44 @@ namespace Microsoft.AspNet.Identity.InMemory.Test
 
         protected override void AddUserStore(IServiceCollection services, object context = null)
         {
-            services.AddSingleton<IUserStore<InMemoryUser>, InMemoryUserStore<InMemoryUser>>();
+            services.AddSingleton<IUserStore<TestUser>, InMemoryUserStore<TestUser>>();
         }
 
         protected override void AddRoleStore(IServiceCollection services, object context = null)
         {
-            services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore<IdentityRole>>();
+            services.AddSingleton<IRoleStore<TestRole>, InMemoryRoleStore<TestRole>>();
         }
+
+        protected override void SetUserPasswordHash(TestUser user, string hashedPassword)
+        {
+            user.PasswordHash = hashedPassword;
+        }
+
+        protected override TestUser CreateTestUser(string namePrefix = "", string email = "", string phoneNumber = "",
+            bool lockoutEnabled = false, DateTimeOffset? lockoutEnd = default(DateTimeOffset?), bool useNamePrefixAsUserName = false)
+        {
+            return new TestUser
+            {
+                UserName = useNamePrefixAsUserName ? namePrefix : string.Format("{0}{1}", namePrefix, Guid.NewGuid()),
+                Email = email,
+                PhoneNumber = phoneNumber,
+                LockoutEnabled = lockoutEnabled,
+                LockoutEnd = lockoutEnd
+            };
+        }
+
+        protected override TestRole CreateTestRole(string roleNamePrefix = "", bool useRoleNamePrefixAsRoleName = false)
+        {
+            var roleName = useRoleNamePrefixAsRoleName ? roleNamePrefix : string.Format("{0}{1}", roleNamePrefix, Guid.NewGuid());
+            return new TestRole(roleName);
+        }
+
+        protected override Expression<Func<TestUser, bool>> UserNameEqualsPredicate(string userName) => u => u.UserName == userName;
+
+        protected override Expression<Func<TestRole, bool>> RoleNameEqualsPredicate(string roleName) => r => r.Name == roleName;
+
+        protected override Expression<Func<TestUser, bool>> UserNameStartsWithPredicate(string userName) => u => u.UserName.StartsWith(userName);
+
+        protected override Expression<Func<TestRole, bool>> RoleNameStartsWithPredicate(string roleName) => r => r.Name.StartsWith(roleName);
     }
 }

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
@@ -7,33 +7,10 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Identity.Test;
 
 namespace Microsoft.AspNet.Identity.InMemory
 {
-    public class InMemoryUser : IdentityUser
-    {
-        public InMemoryUser() { }
-
-        public InMemoryUser(string userName) : base(userName) { }
-
-
-        /// <summary>
-        ///     Roles for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserRole> Roles { get; } = new List<IdentityUserRole>();
-
-        /// <summary>
-        ///     Claims for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserClaim> Claims { get; } = new List<IdentityUserClaim>();
-
-        /// <summary>
-        ///     Associated logins for the user
-        /// </summary>
-        public virtual ICollection<IdentityUserLogin> Logins { get; } = new List<IdentityUserLogin>();
-
-    }
-
     public class InMemoryUserStore<TUser> :
         IUserLoginStore<TUser>,
         IUserRoleStore<TUser>,
@@ -45,7 +22,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         IUserPhoneNumberStore<TUser>,
         IQueryableUserStore<TUser>,
         IUserTwoFactorStore<TUser>
-        where TUser : InMemoryUser
+        where TUser : TestUser
     {
         private readonly Dictionary<string, TUser> _logins = new Dictionary<string, TUser>();
 
@@ -66,7 +43,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         {
             foreach (var claim in claims)
             {
-                user.Claims.Add(new IdentityUserClaim { ClaimType = claim.Type, ClaimValue = claim.Value, UserId = user.Id });
+                user.Claims.Add(new TestUserClaim { ClaimType = claim.Type, ClaimValue = claim.Value, UserId = user.Id });
             }
             return Task.FromResult(0);
         }
@@ -185,7 +162,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         public virtual Task AddLoginAsync(TUser user, UserLoginInfo login,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            user.Logins.Add(new IdentityUserLogin
+            user.Logins.Add(new TestUserLogin
             {
                 UserId = user.Id,
                 ProviderKey = login.ProviderKey,
@@ -328,7 +305,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         // RoleId == roleName for InMemory
         public Task AddToRoleAsync(TUser user, string role, CancellationToken cancellationToken = default(CancellationToken))
         {
-            user.Roles.Add(new IdentityUserRole { RoleId = role, UserId = user.Id });
+            user.Roles.Add(new TestUserRole { RoleId = role, UserId = user.Id });
             return Task.FromResult(0);
         }
 

--- a/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
@@ -18,8 +18,8 @@ namespace Microsoft.AspNet.Identity.Test
         public void CanOverrideUserStore()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddUserStore<MyUberThingy>();
-            var thingy = services.BuildServiceProvider().GetRequiredService<IUserStore<IdentityUser>>() as MyUberThingy;
+            services.AddIdentity<TestUser,TestRole>().AddUserStore<MyUberThingy>();
+            var thingy = services.BuildServiceProvider().GetRequiredService<IUserStore<TestUser>>() as MyUberThingy;
             Assert.NotNull(thingy);
         }
 
@@ -27,8 +27,8 @@ namespace Microsoft.AspNet.Identity.Test
         public void CanOverrideRoleStore()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddRoleStore<MyUberThingy>();
-            var thingy = services.BuildServiceProvider().GetRequiredService<IRoleStore<IdentityRole>>() as MyUberThingy;
+            services.AddIdentity<TestUser,TestRole>().AddRoleStore<MyUberThingy>();
+            var thingy = services.BuildServiceProvider().GetRequiredService<IRoleStore<TestRole>>() as MyUberThingy;
             Assert.NotNull(thingy);
         }
 
@@ -36,8 +36,8 @@ namespace Microsoft.AspNet.Identity.Test
         public void CanOverrideRoleValidator()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddRoleValidator<MyUberThingy>();
-            var thingy = services.BuildServiceProvider().GetRequiredService<IRoleValidator<IdentityRole>>() as MyUberThingy;
+            services.AddIdentity<TestUser,TestRole>().AddRoleValidator<MyUberThingy>();
+            var thingy = services.BuildServiceProvider().GetRequiredService<IRoleValidator<TestRole>>() as MyUberThingy;
             Assert.NotNull(thingy);
         }
 
@@ -45,8 +45,8 @@ namespace Microsoft.AspNet.Identity.Test
         public void CanOverrideUserValidator()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddUserValidator<MyUberThingy>();
-            var thingy = services.BuildServiceProvider().GetRequiredService<IUserValidator<IdentityUser>>() as MyUberThingy;
+            services.AddIdentity<TestUser,TestRole>().AddUserValidator<MyUberThingy>();
+            var thingy = services.BuildServiceProvider().GetRequiredService<IUserValidator<TestUser>>() as MyUberThingy;
             Assert.NotNull(thingy);
         }
 
@@ -54,8 +54,8 @@ namespace Microsoft.AspNet.Identity.Test
         public void CanOverridePasswordValidator()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddPasswordValidator<MyUberThingy>();
-            var thingy = services.BuildServiceProvider().GetRequiredService<IPasswordValidator<IdentityUser>>() as MyUberThingy;
+            services.AddIdentity<TestUser,TestRole>().AddPasswordValidator<MyUberThingy>();
+            var thingy = services.BuildServiceProvider().GetRequiredService<IPasswordValidator<TestUser>>() as MyUberThingy;
             Assert.NotNull(thingy);
         }
 
@@ -85,16 +85,16 @@ namespace Microsoft.AspNet.Identity.Test
         public void EnsureDefaultServices()
         {
             var services = new ServiceCollection();
-            services.AddIdentity();
+            services.AddIdentity<TestUser,TestRole>();
 
             var provider = services.BuildServiceProvider();
-            var userValidator = provider.GetRequiredService<IUserValidator<IdentityUser>>() as UserValidator<IdentityUser>;
+            var userValidator = provider.GetRequiredService<IUserValidator<TestUser>>() as UserValidator<TestUser>;
             Assert.NotNull(userValidator);
 
-            var pwdValidator = provider.GetRequiredService<IPasswordValidator<IdentityUser>>() as PasswordValidator<IdentityUser>;
+            var pwdValidator = provider.GetRequiredService<IPasswordValidator<TestUser>>() as PasswordValidator<TestUser>;
             Assert.NotNull(pwdValidator);
 
-            var hasher = provider.GetRequiredService<IPasswordHasher<IdentityUser>>() as PasswordHasher<IdentityUser>;
+            var hasher = provider.GetRequiredService<IPasswordHasher<TestUser>>() as PasswordHasher<TestUser>;
             Assert.NotNull(hasher);
         }
 
@@ -102,31 +102,31 @@ namespace Microsoft.AspNet.Identity.Test
         public void EnsureDefaultTokenProviders()
         {
             var services = new ServiceCollection();
-            services.AddIdentity().AddDefaultTokenProviders();
+            services.AddIdentity<TestUser,TestRole>().AddDefaultTokenProviders();
 
             var provider = services.BuildServiceProvider();
-            var tokenProviders = provider.GetRequiredService<IEnumerable<IUserTokenProvider<IdentityUser>>>();
+            var tokenProviders = provider.GetRequiredService<IEnumerable<IUserTokenProvider<TestUser>>>();
             Assert.Equal(3, tokenProviders.Count());
         }
 
-        private class MyUberThingy : IUserValidator<IdentityUser>, IPasswordValidator<IdentityUser>, IRoleValidator<IdentityRole>, IUserStore<IdentityUser>, IRoleStore<IdentityRole>
+        private class MyUberThingy : IUserValidator<TestUser>, IPasswordValidator<TestUser>, IRoleValidator<TestRole>, IUserStore<TestUser>, IRoleStore<TestRole>
         {
-            public Task<IdentityResult> CreateAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> CreateAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> CreateAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> CreateAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> DeleteAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> DeleteAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> DeleteAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> DeleteAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
@@ -136,97 +136,97 @@ namespace Microsoft.AspNet.Identity.Test
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityUser> FindByIdAsync(string userId, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<TestUser> FindByIdAsync(string userId, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<TestUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetNormalizedRoleNameAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetNormalizedRoleNameAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetNormalizedUserNameAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetNormalizedUserNameAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetRoleIdAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetRoleIdAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetRoleNameAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetRoleNameAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetUserIdAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetUserIdAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> GetUserNameAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<string> GetUserNameAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task SetNormalizedRoleNameAsync(IdentityRole role, string normalizedName, CancellationToken cancellationToken = default(CancellationToken))
+            public Task SetNormalizedRoleNameAsync(TestRole role, string normalizedName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task SetNormalizedUserNameAsync(IdentityUser user, string normalizedName, CancellationToken cancellationToken = default(CancellationToken))
+            public Task SetNormalizedUserNameAsync(TestUser user, string normalizedName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task SetRoleNameAsync(IdentityRole role, string roleName, CancellationToken cancellationToken = default(CancellationToken))
+            public Task SetRoleNameAsync(TestRole role, string roleName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task SetUserNameAsync(IdentityUser user, string userName, CancellationToken cancellationToken = default(CancellationToken))
+            public Task SetUserNameAsync(TestUser user, string userName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> UpdateAsync(IdentityRole role, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> UpdateAsync(TestRole role, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> UpdateAsync(IdentityUser user, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<IdentityResult> UpdateAsync(TestUser user, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> ValidateAsync(RoleManager<IdentityRole> manager, IdentityRole role)
+            public Task<IdentityResult> ValidateAsync(RoleManager<TestRole> manager, TestRole role)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> ValidateAsync(UserManager<IdentityUser> manager, IdentityUser user)
+            public Task<IdentityResult> ValidateAsync(UserManager<TestUser> manager, TestUser user)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IdentityResult> ValidateAsync(UserManager<IdentityUser> manager, IdentityUser user, string password)
+            public Task<IdentityResult> ValidateAsync(UserManager<TestUser> manager, TestUser user, string password)
             {
                 throw new NotImplementedException();
             }
 
-            Task<IdentityRole> IRoleStore<IdentityRole>.FindByIdAsync(string roleId, CancellationToken cancellationToken)
+            Task<TestRole> IRoleStore<TestRole>.FindByIdAsync(string roleId, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
 
-            Task<IdentityRole> IRoleStore<IdentityRole>.FindByNameAsync(string roleName, CancellationToken cancellationToken)
+            Task<TestRole> IRoleStore<TestRole>.FindByNameAsync(string roleName, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Identity.Test/IdentityOptionsTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/IdentityOptionsTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(roleClaimType, config.Get("identity:claimsidentity:roleclaimtype"));
 
             var services = new ServiceCollection();
-            services.AddIdentity();
+            services.AddIdentity<TestUser,TestRole>();
             services.ConfigureIdentity(config.GetSubKey("identity"));
             var accessor = services.BuildServiceProvider().GetRequiredService<IOptions<IdentityOptions>>();
             Assert.NotNull(accessor);
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.Identity.Test
             var config = new Configuration(new MemoryConfigurationSource(dic));
             var services = new ServiceCollection();
             services.ConfigureIdentity(config.GetSubKey("identity"));
-            services.AddIdentity<IdentityUser, IdentityRole>(o => { o.User.RequireUniqueEmail = false; o.Lockout.MaxFailedAccessAttempts++; });
+            services.AddIdentity<TestUser, TestRole>(o => { o.User.RequireUniqueEmail = false; o.Lockout.MaxFailedAccessAttempts++; });
             var accessor = services.BuildServiceProvider().GetRequiredService<IOptions<IdentityOptions>>();
             Assert.NotNull(accessor);
             var options = accessor.Options;
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var services = new ServiceCollection()
                 .ConfigureOptions<PasswordsNegativeLengthSetup>();
-            services.AddIdentity();
+            services.AddIdentity<TestUser,TestRole>();
             var serviceProvider = services.BuildServiceProvider();
 
             var setup = serviceProvider.GetRequiredService<IConfigureOptions<IdentityOptions>>();
@@ -137,7 +137,7 @@ namespace Microsoft.AspNet.Identity.Test
             var services = new ServiceCollection()
                 .AddOptions()
                 .ConfigureIdentity(options => options.User.RequireUniqueEmail = true);
-            services.AddIdentity();
+            services.AddIdentity<TestUser,TestRole>();
             var serviceProvider = services.BuildServiceProvider();
 
             var optionsGetter = serviceProvider.GetRequiredService<IOptions<IdentityOptions>>();

--- a/test/Microsoft.AspNet.Identity.Test/PasswordValidatorTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/PasswordValidatorTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task ValidateThrowsWithNullTest()
         {
             // Setup
-            var validator = new PasswordValidator<IdentityUser>();
+            var validator = new PasswordValidator<TestUser>();
 
             // Act
             // Assert
@@ -42,8 +42,8 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task FailsIfTooShortTests(string input)
         {
             const string error = "Passwords must be at least 6 characters.";
-            var manager = MockHelpers.TestUserManager<IdentityUser>();
-            var valid = new PasswordValidator<IdentityUser>();
+            var manager = MockHelpers.TestUserManager<TestUser>();
+            var valid = new PasswordValidator<TestUser>();
             manager.Options.Password.RequireUppercase = false;
             manager.Options.Password.RequireNonLetterOrDigit = false;
             manager.Options.Password.RequireLowercase = false;
@@ -56,8 +56,8 @@ namespace Microsoft.AspNet.Identity.Test
         [InlineData("aaaaaaaaaaa")]
         public async Task SuccessIfLongEnoughTests(string input)
         {
-            var manager = MockHelpers.TestUserManager<IdentityUser>();
-            var valid = new PasswordValidator<IdentityUser>();
+            var manager = MockHelpers.TestUserManager<TestUser>();
+            var valid = new PasswordValidator<TestUser>();
             manager.Options.Password.RequireUppercase = false;
             manager.Options.Password.RequireNonLetterOrDigit = false;
             manager.Options.Password.RequireLowercase = false;
@@ -70,8 +70,8 @@ namespace Microsoft.AspNet.Identity.Test
         [InlineData("aaaaaaaaaaa")]
         public async Task FailsWithoutRequiredNonAlphanumericTests(string input)
         {
-            var manager = MockHelpers.TestUserManager<IdentityUser>();
-            var valid = new PasswordValidator<IdentityUser>();
+            var manager = MockHelpers.TestUserManager<TestUser>();
+            var valid = new PasswordValidator<TestUser>();
             manager.Options.Password.RequireUppercase = false;
             manager.Options.Password.RequireNonLetterOrDigit = true;
             manager.Options.Password.RequireLowercase = false;
@@ -87,8 +87,8 @@ namespace Microsoft.AspNet.Identity.Test
         [InlineData("!!!!!!")]
         public async Task SucceedsWithRequiredNonAlphanumericTests(string input)
         {
-            var manager = MockHelpers.TestUserManager<IdentityUser>();
-            var valid = new PasswordValidator<IdentityUser>();
+            var manager = MockHelpers.TestUserManager<TestUser>();
+            var valid = new PasswordValidator<TestUser>();
             manager.Options.Password.RequireUppercase = false;
             manager.Options.Password.RequireNonLetterOrDigit = true;
             manager.Options.Password.RequireLowercase = false;
@@ -111,8 +111,8 @@ namespace Microsoft.AspNet.Identity.Test
             const string lowerError = "Passwords must have at least one lowercase ('a'-'z').";
             const string digitError = "Passwords must have at least one digit ('0'-'9').";
             const string lengthError = "Passwords must be at least 6 characters.";
-            var manager = MockHelpers.TestUserManager<IdentityUser>();
-            var valid = new PasswordValidator<IdentityUser>();
+            var manager = MockHelpers.TestUserManager<TestUser>();
+            var valid = new PasswordValidator<TestUser>();
             var errors = new List<string>();
             if ((errorMask & Errors.Length) != Errors.None)
             {

--- a/test/Microsoft.AspNet.Identity.Test/SecurityStampValidatorTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/SecurityStampValidatorTest.cs
@@ -35,23 +35,23 @@ namespace Microsoft.AspNet.Identity.Test
         [InlineData(false)]
         public async Task OnValidatePrincipalTestSuccess(bool isPersistent)
         {
-            var user = new IdentityUser("test");
-            var userManager = MockHelpers.MockUserManager<IdentityUser>();
-            var claimsManager = new Mock<IUserClaimsPrincipalFactory<IdentityUser>>();
+            var user = new TestUser("test");
+            var userManager = MockHelpers.MockUserManager<TestUser>();
+            var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
             var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var options = new Mock<IOptions<IdentityOptions>>();
             options.Setup(a => a.Options).Returns(identityOptions);
             var httpContext = new Mock<HttpContext>();
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
-            var signInManager = new Mock<SignInManager<IdentityUser>>(userManager.Object,
+            var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
                 contextAccessor.Object, claimsManager.Object, options.Object, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>(), user.Id)).ReturnsAsync(user).Verifiable();
             signInManager.Setup(s => s.SignInAsync(user, isPersistent, null)).Returns(Task.FromResult(0)).Verifiable();
             var services = new ServiceCollection();
             services.AddInstance(options.Object);
             services.AddInstance(signInManager.Object);
-            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<IdentityUser>());
+            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<TestUser>());
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
             var id = new ClaimsIdentity(IdentityOptions.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
@@ -72,22 +72,22 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public async Task OnValidateIdentityRejectsWhenValidateSecurityStampFails()
         {
-            var user = new IdentityUser("test");
-            var userManager = MockHelpers.MockUserManager<IdentityUser>();
-            var claimsManager = new Mock<IUserClaimsPrincipalFactory<IdentityUser>>();
+            var user = new TestUser("test");
+            var userManager = MockHelpers.MockUserManager<TestUser>();
+            var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
             var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var options = new Mock<IOptions<IdentityOptions>>();
             options.Setup(a => a.Options).Returns(identityOptions);
             var httpContext = new Mock<HttpContext>();
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
-            var signInManager = new Mock<SignInManager<IdentityUser>>(userManager.Object,
+            var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
                 contextAccessor.Object, claimsManager.Object, options.Object, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>(), user.Id)).ReturnsAsync(null).Verifiable();
             var services = new ServiceCollection();
             services.AddInstance(options.Object);
             services.AddInstance(signInManager.Object);
-            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<IdentityUser>());
+            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<TestUser>());
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
             var id = new ClaimsIdentity(IdentityOptions.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
@@ -107,22 +107,22 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public async Task OnValidateIdentityRejectsWhenNoIssuedUtc()
         {
-            var user = new IdentityUser("test");
+            var user = new TestUser("test");
             var httpContext = new Mock<HttpContext>();
-            var userManager = MockHelpers.MockUserManager<IdentityUser>();
-            var claimsManager = new Mock<IUserClaimsPrincipalFactory<IdentityUser>>();
+            var userManager = MockHelpers.MockUserManager<TestUser>();
+            var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
             var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var options = new Mock<IOptions<IdentityOptions>>();
             options.Setup(a => a.Options).Returns(identityOptions);
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
-            var signInManager = new Mock<SignInManager<IdentityUser>>(userManager.Object,
+            var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
                 contextAccessor.Object, claimsManager.Object, options.Object, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>(), user.Id)).ReturnsAsync(null).Verifiable();
             var services = new ServiceCollection();
             services.AddInstance(options.Object);
             services.AddInstance(signInManager.Object);
-            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<IdentityUser>());
+            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<TestUser>());
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
             var id = new ClaimsIdentity(IdentityOptions.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
@@ -142,23 +142,23 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public async Task OnValidateIdentityDoesNotRejectsWhenNotExpired()
         {
-            var user = new IdentityUser("test");
+            var user = new TestUser("test");
             var httpContext = new Mock<HttpContext>();
-            var userManager = MockHelpers.MockUserManager<IdentityUser>();
-            var claimsManager = new Mock<IUserClaimsPrincipalFactory<IdentityUser>>();
+            var userManager = MockHelpers.MockUserManager<TestUser>();
+            var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
             var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.FromDays(1) };
             var options = new Mock<IOptions<IdentityOptions>>();
             options.Setup(a => a.Options).Returns(identityOptions);
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
-            var signInManager = new Mock<SignInManager<IdentityUser>>(userManager.Object,
+            var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
                 contextAccessor.Object, claimsManager.Object, options.Object, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>(), user.Id)).Throws(new Exception("Shouldn't be called"));
             signInManager.Setup(s => s.SignInAsync(user, false, null)).Throws(new Exception("Shouldn't be called"));
             var services = new ServiceCollection();
             services.AddInstance(options.Object);
             services.AddInstance(signInManager.Object);
-            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<IdentityUser>());
+            services.AddInstance<ISecurityStampValidator>(new SecurityStampValidator<TestUser>());
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
             var id = new ClaimsIdentity(IdentityOptions.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));

--- a/test/Microsoft.AspNet.Identity.Test/SignInManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/SignInManagerTest.cs
@@ -68,14 +68,14 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public void ConstructorNullChecks()
         {
-            Assert.Throws<ArgumentNullException>("userManager", () => new SignInManager<IdentityUser>(null, null, null, null, null));
-            var userManager = MockHelpers.MockUserManager<IdentityUser>().Object;
-            Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<IdentityUser>(userManager, null, null, null));
+            Assert.Throws<ArgumentNullException>("userManager", () => new SignInManager<TestUser>(null, null, null, null, null));
+            var userManager = MockHelpers.MockUserManager<TestUser>().Object;
+            Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<TestUser>(userManager, null, null, null));
             var contextAccessor = new Mock<IHttpContextAccessor>();
-            Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<IdentityUser>(userManager, contextAccessor.Object, null, null));
+            Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<TestUser>(userManager, contextAccessor.Object, null, null));
             var context = new Mock<HttpContext>();
             contextAccessor.Setup(a => a.HttpContext).Returns(context.Object);
-            Assert.Throws<ArgumentNullException>("claimsFactory", () => new SignInManager<IdentityUser>(userManager, contextAccessor.Object, null, null));
+            Assert.Throws<ArgumentNullException>("claimsFactory", () => new SignInManager<TestUser>(userManager, contextAccessor.Object, null, null));
         }
 
         //TODO: Mock fails in K (this works fine in net45)

--- a/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Identity.Test;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -20,7 +21,7 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var services = new ServiceCollection()
                     .AddTransient<IUserStore<TestUser>, NoopUserStore>();
-            services.AddIdentity<TestUser, IdentityRole>();
+            services.AddIdentity<TestUser, TestRole>();
             var manager = services.BuildServiceProvider().GetRequiredService<UserManager<TestUser>>();
             Assert.NotNull(manager.PasswordHasher);
             Assert.NotNull(manager.Store);
@@ -544,8 +545,8 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public async Task SecurityStampMethodsFailWhenStoreNotImplemented()
         {
-            var store = new Mock<IUserStore<IdentityUser>>();
-            store.Setup(x => x.GetUserIdAsync(It.IsAny<IdentityUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(Guid.NewGuid().ToString()));
+            var store = new Mock<IUserStore<TestUser>>();
+            store.Setup(x => x.GetUserIdAsync(It.IsAny<TestUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(Guid.NewGuid().ToString()));
             var manager = MockHelpers.TestUserManager(store.Object);
             Assert.False(manager.SupportsUserSecurityStamp);
             await Assert.ThrowsAsync<NotSupportedException>(() => manager.UpdateSecurityStampAsync(null));
@@ -636,8 +637,8 @@ namespace Microsoft.AspNet.Identity.Test
         [Fact]
         public async Task ResetTokenCallNoopForTokenValueZero()
         {
-            var user = new IdentityUser() { UserName = Guid.NewGuid().ToString()};
-            var store = new Mock<IUserLockoutStore<IdentityUser>>();
+            var user = new TestUser() { UserName = Guid.NewGuid().ToString()};
+            var store = new Mock<IUserLockoutStore<TestUser>>();
             store.Setup(x => x.ResetAccessFailedCountAsync(user, It.IsAny<CancellationToken>())).Returns(() =>
                {
                    throw new Exception();
@@ -1372,7 +1373,7 @@ namespace Microsoft.AspNet.Identity.Test
             var describer = new TestErrorDescriber();
             services.AddInstance<IdentityErrorDescriber>(describer)
                 .AddInstance<IUserStore<TestUser>>(store.Object)
-                .AddIdentity<TestUser, IdentityRole>();
+                .AddIdentity<TestUser, TestRole>();
 
             var manager = services.BuildServiceProvider().GetRequiredService<UserManager<TestUser>>();
 

--- a/test/Shared/ApplicationUser.cs
+++ b/test/Shared/ApplicationUser.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-namespace Microsoft.AspNet.Identity.Test
-{
-    public class ApplicationUser : IdentityUser { }
-}

--- a/test/Shared/TestRole.cs
+++ b/test/Shared/TestRole.cs
@@ -1,11 +1,70 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+
 namespace Microsoft.AspNet.Identity.Test
 {
-    public class TestRole
+    /// <summary>
+    ///     Represents a Role entity
+    /// </summary>
+    public class TestRole : TestRole<string>
     {
-        public string Id { get; private set; }
-        public string Name { get; set; }
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        public TestRole()
+        {
+            Id = Guid.NewGuid().ToString();
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="roleName"></param>
+        public TestRole(string roleName) : this()
+        {
+            Name = roleName;
+        }
+    }
+
+    /// <summary>
+    ///     Represents a Role entity
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public class TestRole<TKey> where TKey : IEquatable<TKey>
+    {
+        public TestRole() { }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="roleName"></param>
+        public TestRole(string roleName) : this()
+        {
+            Name = roleName;
+        }
+
+        /// <summary>
+        ///     Role id
+        /// </summary>
+        public virtual TKey Id { get; set; }
+
+        /// <summary>
+        /// Navigation property for claims in the role
+        /// </summary>
+        public virtual ICollection<TestRoleClaim<TKey>> Claims { get; private set; } = new List<TestRoleClaim<TKey>>();
+
+        /// <summary>
+        ///     Role name
+        /// </summary>
+        public virtual string Name { get; set; }
+        public virtual string NormalizedName { get; set; }
+
+        /// <summary>
+        /// A random value that should change whenever a role is persisted to the store
+        /// </summary>
+        public virtual string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
     }
 }

--- a/test/Shared/TestRoleClaim.cs
+++ b/test/Shared/TestRoleClaim.cs
@@ -3,15 +3,15 @@
 
 using System;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.Test
 {
-    public class IdentityRoleClaim : IdentityRoleClaim<string> { }
+    public class TestRoleClaim : TestRoleClaim<string> { }
 
     /// <summary>
     ///     EntityType that represents one specific role claim
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
-    public class IdentityRoleClaim<TKey> where TKey : IEquatable<TKey>
+    public class TestRoleClaim<TKey> where TKey : IEquatable<TKey>
     {
         /// <summary>
         ///     Primary key

--- a/test/Shared/TestUser.cs
+++ b/test/Shared/TestUser.cs
@@ -2,18 +2,104 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNet.Identity.Test
 {
-    public class TestUser
+    public class TestUser : TestUser<string>
     {
         public TestUser()
         {
             Id = Guid.NewGuid().ToString();
         }
 
-        public string Id { get; private set; }
-        public string UserName { get; set; }
-        public string Email { get; set; }
+        public TestUser(string userName) : this()
+        {
+            UserName = userName;
+        }
+    }
+
+    public class TestUser<TKey> where TKey : IEquatable<TKey>
+    {
+        public TestUser() { }
+
+        public TestUser(string userName) : this()
+        {
+            UserName = userName;
+        }
+
+        public virtual TKey Id { get; set; }
+        public virtual string UserName { get; set; }
+        public virtual string NormalizedUserName { get; set; }
+
+        /// <summary>
+        ///     Email
+        /// </summary>
+        public virtual string Email { get; set; }
+
+        public virtual string NormalizedEmail { get; set; }
+
+        /// <summary>
+        ///     True if the email is confirmed, default is false
+        /// </summary>
+        public virtual bool EmailConfirmed { get; set; }
+
+        /// <summary>
+        ///     The salted/hashed form of the user password
+        /// </summary>
+        public virtual string PasswordHash { get; set; }
+
+        /// <summary>
+        /// A random value that should change whenever a users credentials change (password changed, login removed)
+        /// </summary>
+        public virtual string SecurityStamp { get; set; }
+
+        /// <summary>
+        /// A random value that should change whenever a user is persisted to the store
+        /// </summary>
+        public virtual string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        ///     PhoneNumber for the user
+        /// </summary>
+        public virtual string PhoneNumber { get; set; }
+
+        /// <summary>
+        ///     True if the phone number is confirmed, default is false
+        /// </summary>
+        public virtual bool PhoneNumberConfirmed { get; set; }
+
+        /// <summary>
+        ///     Is two factor enabled for the user
+        /// </summary>
+        public virtual bool TwoFactorEnabled { get; set; }
+
+        /// <summary>
+        ///     DateTime in UTC when lockout ends, any time in the past is considered not locked out.
+        /// </summary>
+        public virtual DateTimeOffset? LockoutEnd { get; set; }
+
+        /// <summary>
+        ///     Is lockout enabled for this user
+        /// </summary>
+        public virtual bool LockoutEnabled { get; set; }
+
+        /// <summary>
+        ///     Used to record failures for the purposes of lockout
+        /// </summary>
+        public virtual int AccessFailedCount { get; set; }
+
+        /// <summary>
+        /// Navigation property for users in the role
+        /// </summary>
+        public virtual ICollection<TestUserRole<TKey>> Roles { get; private set; } = new List<TestUserRole<TKey>>();
+        /// <summary>
+        /// Navigation property for users claims
+        /// </summary>
+        public virtual ICollection<TestUserClaim<TKey>> Claims { get; private set; } = new List<TestUserClaim<TKey>>();
+        /// <summary>
+        /// Navigation property for users logins
+        /// </summary>
+        public virtual ICollection<TestUserLogin<TKey>> Logins { get; private set; } = new List<TestUserLogin<TKey>>();
     }
 }

--- a/test/Shared/TestUserClaim.cs
+++ b/test/Shared/TestUserClaim.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Identity.Test
+{
+    public class TestUserClaim : TestUserClaim<string> { }
+
+    /// <summary>
+    ///     EntityType that represents one specific user claim
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public class TestUserClaim<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        ///     Primary key
+        /// </summary>
+        public virtual int Id { get; set; }
+
+        /// <summary>
+        ///     User Id for the user who owns this claim
+        /// </summary>
+        public virtual TKey UserId { get; set; }
+
+        /// <summary>
+        ///     Claim type
+        /// </summary>
+        public virtual string ClaimType { get; set; }
+
+        /// <summary>
+        ///     Claim value
+        /// </summary>
+        public virtual string ClaimValue { get; set; }
+    }
+}

--- a/test/Shared/TestUserLogin.cs
+++ b/test/Shared/TestUserLogin.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Identity.Test
+{
+    public class TestUserLogin : TestUserLogin<string> { }
+
+    /// <summary>
+    ///     Entity type for a user's login (i.e. facebook, google)
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public class TestUserLogin<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        ///     The login provider for the login (i.e. facebook, google)
+        /// </summary>
+        public virtual string LoginProvider { get; set; }
+
+        /// <summary>
+        ///     Key representing the login for the provider
+        /// </summary>
+        public virtual string ProviderKey { get; set; }
+
+        /// <summary>
+        ///     Display name for the login
+        /// </summary>
+        public virtual string ProviderDisplayName { get; set; }
+
+        /// <summary>
+        ///     User Id for the user who owns this login
+        /// </summary>
+        public virtual TKey UserId { get; set; }
+    }
+}

--- a/test/Shared/TestUserRole.cs
+++ b/test/Shared/TestUserRole.cs
@@ -3,15 +3,15 @@
 
 using System;
 
-namespace Microsoft.AspNet.Identity
+namespace Microsoft.AspNet.Identity.Test
 {
-    public class IdentityUserRole : IdentityUserRole<string> { }
+    public class TestUserRole : TestUserRole<string> { }
 
     /// <summary>
     ///     EntityType that represents a user belonging to a role
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
-    public class IdentityUserRole<TKey> where TKey : IEquatable<TKey>
+    public class TestUserRole<TKey> where TKey : IEquatable<TKey>
     {
         /// <summary>
         ///     UserId for the user that is in the role

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -596,7 +596,7 @@ namespace Microsoft.AspNet.Identity.Test
             var mgr = CreateManager();
             if (mgr.SupportsQueryableUsers)
             {
-                var users = GenerateUsers("CanFindUsersViaUserQuerable", 3);
+                var users = GenerateUsers("CanFindUsersViaUserQuerable", 4);
                 foreach (var u in users)
                 {
                     IdentityResultAssert.IsSuccess(await mgr.CreateAsync(u));
@@ -1105,8 +1105,7 @@ namespace Microsoft.AspNet.Identity.Test
                     IdentityResultAssert.IsSuccess(await manager.CreateAsync(r));
                 }
                 Assert.Equal(roles.Count, manager.Roles.Count(RoleNameStartsWithPredicate("CanQuerableRolesTest")));
-                var r1 = manager.Roles.FirstOrDefault(RoleNameStartsWithPredicate("CanQuerableRolesTest1"));
-                Assert.Equal(roles[1], r1);
+                Assert.Null(manager.Roles.FirstOrDefault(RoleNameEqualsPredicate("bogus")));
             }
         }
 

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -11,18 +11,19 @@ using Microsoft.AspNet.Testing;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Xunit;
+using System.Linq.Expressions;
 
 namespace Microsoft.AspNet.Identity.Test
 {
     // Common functionality tests that all verifies user manager functionality regardless of store implementation
     public abstract class UserManagerTestBase<TUser, TRole> : UserManagerTestBase<TUser, TRole, string>
-        where TUser : IdentityUser, new()
-        where TRole : IdentityRole, new()
+        where TUser : class
+        where TRole : class
     { }
 
     public abstract class UserManagerTestBase<TUser, TRole, TKey>
-        where TUser : IdentityUser<TKey>, new()
-        where TRole : IdentityRole<TKey>, new()
+        where TUser : class
+        where TRole : class
         where TKey : IEquatable<TKey>
     {
         protected TestLoggerFactory loggerFactory;
@@ -82,15 +83,18 @@ namespace Microsoft.AspNet.Identity.Test
         protected abstract void AddUserStore(IServiceCollection services, object context = null);
         protected abstract void AddRoleStore(IServiceCollection services, object context = null);
 
-        protected TUser CreateTestUser(string namePrefix = "")
-        {
-            return new TUser() { UserName = namePrefix + Guid.NewGuid().ToString() };
-        }
+        protected abstract void SetUserPasswordHash(TUser user, string hashedPassword);
 
-        protected TRole CreateRole(string namePrefix = "")
-        {
-            return new TRole() { Name = namePrefix + Guid.NewGuid().ToString() };
-        }
+        protected abstract TUser CreateTestUser(string namePrefix = "", string email = "", string phoneNumber = "",
+            bool lockoutEnabled = false, DateTimeOffset? lockoutEnd = null, bool useNamePrefixAsUserName = false);
+
+        protected abstract TRole CreateTestRole(string roleNamePrefix = "", bool useRoleNamePrefixAsRoleName = false);
+
+        protected abstract Expression<Func<TUser, bool>> UserNameEqualsPredicate(string userName);
+        protected abstract Expression<Func<TUser, bool>> UserNameStartsWithPredicate(string userName);
+
+        protected abstract Expression<Func<TRole, bool>> RoleNameEqualsPredicate(string roleName);
+        protected abstract Expression<Func<TRole, bool>> RoleNameStartsWithPredicate(string roleName);
 
         [Fact]
         public async Task CanDeleteUser()
@@ -98,12 +102,13 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateManager();
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "CreateAsync", user.Id.ToString());
+            var userId = await manager.GetUserIdAsync(user);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "CreateAsync", userId);
 
             IdentityResultAssert.IsSuccess(await manager.DeleteAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "DeleteAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "DeleteAsync", userId);
 
-            Assert.Null(await manager.FindByIdAsync(user.Id.ToString()));
+            Assert.Null(await manager.FindByIdAsync(userId));
         }
 
         [Fact]
@@ -111,13 +116,13 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             var name = Guid.NewGuid().ToString();
-            var user = new TUser() { UserName = name };
+            var user = CreateTestUser(name);
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             var newName = Guid.NewGuid().ToString();
             Assert.Null(await manager.FindByNameAsync(newName));
-            user.UserName = newName;
+            IdentityResultAssert.IsSuccess(await manager.SetUserNameAsync(user, newName));
             IdentityResultAssert.IsSuccess(await manager.UpdateAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "UpdateAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "UpdateAsync", await manager.GetUserIdAsync(user));
             Assert.NotNull(await manager.FindByNameAsync(newName));
             Assert.Null(await manager.FindByNameAsync(name));
         }
@@ -126,7 +131,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanSetUserName()
         {
             var manager = CreateManager();
-            var user = new TUser() { UserName = "UpdateAsync" };
+            var user = CreateTestUser("UpdateAsync");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.Null(await manager.FindByNameAsync("New"));
             IdentityResultAssert.IsSuccess(await manager.SetUserNameAsync(user, "New"));
@@ -138,13 +143,14 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanUpdatePasswordUsingHasher()
         {
             var manager = CreateManager();
-            var user = new TUser() { UserName = "UpdatePassword" };
+            var user = CreateTestUser("UpdatePassword");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, "password"));
             Assert.True(await manager.CheckPasswordAsync(user, "password"));
+            var userId = await manager.GetUserIdAsync(user);
             string expectedLog = string.Format("{0} : {1}", "CheckPasswordAsync", true.ToString());
             IdentityResultAssert.VerifyLogMessage(manager.Logger, expectedLog);
 
-            user.PasswordHash = manager.PasswordHasher.HashPassword(user, "New");
+            SetUserPasswordHash(user, manager.PasswordHasher.HashPassword(user, "New"));
             IdentityResultAssert.IsSuccess(await manager.UpdateAsync(user));
             Assert.False(await manager.CheckPasswordAsync(user, "password"));
             expectedLog = string.Format("{0} : {1}", "CheckPasswordAsync", false.ToString());
@@ -158,7 +164,7 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateManager();
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            Assert.NotNull(await manager.FindByIdAsync(user.Id.ToString()));
+            Assert.NotNull(await manager.FindByIdAsync(await manager.GetUserIdAsync(user)));
         }
 
         [Fact]
@@ -180,7 +186,7 @@ namespace Microsoft.AspNet.Identity.Test
             manager.UserValidators.Clear();
             manager.UserValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.UpdateAsync(user), AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "UpdateAsync", user.Id.ToString(), AlwaysBadValidator.ErrorMessage);
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "UpdateAsync", await manager.GetUserIdAsync(user), AlwaysBadValidator.ErrorMessage);
         }
 
         [Fact]
@@ -213,7 +219,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task UserValidatorBlocksInvalidEmailsWhenRequiresUniqueEmail(string email)
         {
             var manager = CreateManager();
-            var user = new TUser() { UserName = "UpdateBlocked", Email = email };
+            var user = CreateTestUser("UpdateBlocked", email);
             manager.Options.User.RequireUniqueEmail = true;
             IdentityResultAssert.IsFailure(await manager.CreateAsync(user), IdentityErrorDescriber.Default.InvalidEmail(email));
         }
@@ -229,7 +235,7 @@ namespace Microsoft.AspNet.Identity.Test
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.AddPasswordAsync(user, "password"),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddPasswordAsync", user.Id.ToString(), AlwaysBadValidator.ErrorMessage);
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddPasswordAsync", await manager.GetUserIdAsync(user), AlwaysBadValidator.ErrorMessage);
         }
 
         [Fact]
@@ -256,7 +262,7 @@ namespace Microsoft.AspNet.Identity.Test
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.ChangePasswordAsync(user, "password", "new"),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePasswordAsync", user.Id.ToString(), AlwaysBadValidator.ErrorMessage);
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePasswordAsync", await manager.GetUserIdAsync(user), AlwaysBadValidator.ErrorMessage);
         }
 
         [Fact]
@@ -273,10 +279,11 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanCreateUserNoPassword()
         {
             var manager = CreateManager();
-            IdentityResultAssert.IsSuccess(await manager.CreateAsync(new TUser() { UserName = "CreateUserTest" }));
-            var user = await manager.FindByNameAsync("CreateUserTest");
+            var username = "CreateUserTest" + Guid.NewGuid();
+            IdentityResultAssert.IsSuccess(await manager.CreateAsync(CreateTestUser(username, useNamePrefixAsUserName: true)));
+            var user = await manager.FindByNameAsync(username);
             Assert.NotNull(user);
-            Assert.Null(user.PasswordHash);
+            Assert.False(await manager.HasPasswordAsync(user));
             var logins = await manager.GetLoginsAsync(user);
             Assert.NotNull(logins);
             Assert.Equal(0, logins.Count());
@@ -289,11 +296,10 @@ namespace Microsoft.AspNet.Identity.Test
             const string provider = "ZzAuth";
             const string display = "display";
             var user = CreateTestUser();
-            var providerKey = user.Id.ToString();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            user = await manager.FindByNameAsync(user.UserName);
+            var providerKey = await manager.GetUserIdAsync(user);
             IdentityResultAssert.IsSuccess(await manager.AddLoginAsync(user, new UserLoginInfo(provider, providerKey, display)));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddLoginAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddLoginAsync", await manager.GetUserIdAsync(user));
             var logins = await manager.GetLoginsAsync(user);
             Assert.NotNull(logins);
             Assert.Equal(1, logins.Count());
@@ -307,12 +313,13 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             var user = CreateTestUser();
-            var login = new UserLoginInfo("Provider", user.Id.ToString(), "display");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            var userId = await manager.GetUserIdAsync(user);
+            var login = new UserLoginInfo("Provider", userId, "display");
             IdentityResultAssert.IsSuccess(await manager.AddLoginAsync(user, login));
             Assert.False(await manager.HasPasswordAsync(user));
             IdentityResultAssert.IsSuccess(await manager.AddPasswordAsync(user, "password"));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddPasswordAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddPasswordAsync", userId);
             Assert.True(await manager.HasPasswordAsync(user));
             var logins = await manager.GetLoginsAsync(user);
             Assert.NotNull(logins);
@@ -330,7 +337,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await manager.HasPasswordAsync(user));
             IdentityResultAssert.IsFailure(await manager.AddPasswordAsync(user, "password"),
                 "User already has a password set.");
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddPasswordAsync", user.Id.ToString(), IdentityErrorDescriber.Default.UserAlreadyHasPassword());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddPasswordAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.UserAlreadyHasPassword());
         }
 
         [Fact]
@@ -338,9 +345,10 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             var user = CreateTestUser();
-            var login = new UserLoginInfo("Provider", user.Id.ToString(), "display");
             var result = await manager.CreateAsync(user);
             Assert.NotNull(user);
+            var userId = await manager.GetUserIdAsync(user);
+            var login = new UserLoginInfo("Provider", userId, "display");
             IdentityResultAssert.IsSuccess(result);
             IdentityResultAssert.IsSuccess(await manager.AddLoginAsync(user, login));
             Assert.Equal(user, await manager.FindByLoginAsync(login.LoginProvider, login.ProviderKey));
@@ -350,30 +358,31 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(login.LoginProvider, logins.Last().LoginProvider);
             Assert.Equal(login.ProviderKey, logins.Last().ProviderKey);
             Assert.Equal(login.ProviderDisplayName, logins.Last().ProviderDisplayName);
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             IdentityResultAssert.IsSuccess(await manager.RemoveLoginAsync(user, login.LoginProvider, login.ProviderKey));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemoveLoginAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemoveLoginAsync", userId);
             Assert.Null(await manager.FindByLoginAsync(login.LoginProvider, login.ProviderKey));
             logins = await manager.GetLoginsAsync(user);
             Assert.NotNull(logins);
             Assert.Equal(0, logins.Count());
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task CanRemovePassword()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
+            var user = CreateTestUser("CanRemovePassword");
             const string password = "password";
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, password));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
+            var username = await manager.GetUserNameAsync(user);
             IdentityResultAssert.IsSuccess(await manager.RemovePasswordAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemovePasswordAsync", user.Id.ToString());
-            var u = await manager.FindByNameAsync(user.UserName);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemovePasswordAsync", await manager.GetUserIdAsync(user));
+            var u = await manager.FindByNameAsync(username);
             Assert.NotNull(u);
-            Assert.Null(u.PasswordHash);
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.False(await manager.HasPasswordAsync(user));
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -384,13 +393,13 @@ namespace Microsoft.AspNet.Identity.Test
             const string password = "password";
             const string newPassword = "newpassword";
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, password));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             IdentityResultAssert.IsSuccess(await manager.ChangePasswordAsync(user, password, newPassword));
             Assert.False(await manager.CheckPasswordAsync(user, password));
             Assert.True(await manager.CheckPasswordAsync(user, newPassword));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangePasswordAsync", user.Id.ToString());
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangePasswordAsync", await manager.GetUserIdAsync(user));
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact(Skip = "Temporarily skipping")]
@@ -404,11 +413,12 @@ namespace Microsoft.AspNet.Identity.Test
             {
                 IdentityResultAssert.IsSuccess(await manager.AddClaimAsync(user, c));
             }
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddClaimsAsync", user.Id.ToString());
+            var userId = await manager.GetUserIdAsync(user);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddClaimsAsync", userId);
             var userClaims = await manager.GetClaimsAsync(user);
             Assert.Equal(3, userClaims.Count);
             IdentityResultAssert.IsSuccess(await manager.RemoveClaimAsync(user, claims[0]));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemoveClaimsAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "RemoveClaimsAsync", userId);
             userClaims = await manager.GetClaimsAsync(user);
             Assert.Equal(2, userClaims.Count);
             IdentityResultAssert.IsSuccess(await manager.RemoveClaimAsync(user, claims[1]));
@@ -460,7 +470,7 @@ namespace Microsoft.AspNet.Identity.Test
             Claim claim = new Claim("c", "b");
             Claim oldClaim = userClaims.FirstOrDefault();
             IdentityResultAssert.IsSuccess(await manager.ReplaceClaimAsync(user, oldClaim, claim));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ReplaceClaimAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ReplaceClaimAsync", await manager.GetUserIdAsync(user));
             var newUserClaims = await manager.GetClaimsAsync(user);
             Assert.Equal(1, newUserClaims.Count);
             Claim newClaim = newUserClaims.FirstOrDefault();
@@ -505,43 +515,40 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, "password"));
             var result = await manager.ChangePasswordAsync(user, "bogus", "newpassword");
             IdentityResultAssert.IsFailure(result, "Incorrect password.");
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePasswordAsync", user.Id.ToString(), IdentityErrorDescriber.Default.PasswordMismatch());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePasswordAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.PasswordMismatch());
         }
 
         [Fact]
         public async Task AddDupeUserNameFails()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            var user2 = new TUser() { UserName = user.UserName };
+            var username = "AddDupeUserNameFails" + Guid.NewGuid();
+            var user = CreateTestUser(username, useNamePrefixAsUserName: true);
+            var user2 = CreateTestUser(username, useNamePrefixAsUserName: true);
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), IdentityErrorDescriber.Default.DuplicateUserName(user.UserName));
+            IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), IdentityErrorDescriber.Default.DuplicateUserName(username));
         }
 
         [Fact]
         public async Task AddDupeEmailAllowedByDefault()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            var user2 = CreateTestUser();
-            user.Email = "yup@yup.com";
-            user2.Email = "yup@yup.com";
+            var user = CreateTestUser(email: "yup@yup.com");
+            var user2 = CreateTestUser(email: "yup@yup.com");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user2));
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user2, await manager.GetEmailAsync(user)));
         }
 
         [Fact]
-        public async Task AddDupeEmailFallsWhenUniqueEmailRequired()
+        public async Task AddDupeEmailFailsWhenUniqueEmailRequired()
         {
             var manager = CreateManager();
             manager.Options.User.RequireUniqueEmail = true;
-            var user = CreateTestUser();
-            var user2 = CreateTestUser();
-            string email = user.UserName + "@yup.com";
-            user.Email = email;
-            user2.Email = email;
+            var user = CreateTestUser(email: "FooUser@yup.com");
+            var user2 = CreateTestUser(email: "FooUser@yup.com");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), IdentityErrorDescriber.Default.DuplicateEmail(user.Email));
+            IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), IdentityErrorDescriber.Default.DuplicateEmail("FooUser@yup.com"));
         }
 
         [Fact]
@@ -549,13 +556,13 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             var user = CreateTestUser();
-            Assert.Null(user.SecurityStamp);
+            Assert.Null(await manager.GetSecurityStampAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             IdentityResultAssert.IsSuccess(await manager.UpdateSecurityStampAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "UpdateSecurityStampAsync", user.Id.ToString());
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "UpdateSecurityStampAsync", await manager.GetUserIdAsync(user));
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -568,17 +575,16 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.AddLoginAsync(user, login));
             var result = await manager.AddLoginAsync(user, login);
             IdentityResultAssert.IsFailure(result, IdentityErrorDescriber.Default.LoginAlreadyAssociated());
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddLoginAsync", user.Id.ToString(), IdentityErrorDescriber.Default.LoginAlreadyAssociated());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "AddLoginAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.LoginAlreadyAssociated());
         }
 
         // Email tests
         [Fact]
         public async Task CanFindByEmail()
         {
+            var email = "foouser@test.com";
             var manager = CreateManager();
-            var user = CreateTestUser();
-            var email = user.UserName + "@test.com";
-            user.Email = email;
+            var user = CreateTestUser(email: email);
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             var fetch = await manager.FindByEmailAsync(email);
             Assert.Equal(user, fetch);
@@ -588,13 +594,16 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanFindUsersViaUserQuerable()
         {
             var mgr = CreateManager();
-            var users = GenerateUsers("CanFindUsersViaUserQuerable", 3);
-            foreach (var u in users)
+            if (mgr.SupportsQueryableUsers)
             {
-                IdentityResultAssert.IsSuccess(await mgr.CreateAsync(u));
+                var users = GenerateUsers("CanFindUsersViaUserQuerable", 3);
+                foreach (var u in users)
+                {
+                    IdentityResultAssert.IsSuccess(await mgr.CreateAsync(u));
+                }
+                Assert.Equal(users.Count, mgr.Users.Count(UserNameStartsWithPredicate("CanFindUsersViaUserQuerable")));
+                Assert.Null(mgr.Users.FirstOrDefault(UserNameEqualsPredicate("bogus")));
             }
-            var usersQ = mgr.Users.Where(u => u.UserName.StartsWith("CanFindUsersViaUserQuerable"));
-            Assert.Null(mgr.Users.FirstOrDefault(u => u.UserName == "bogus"));
         }
 
         [Fact]
@@ -610,14 +619,14 @@ namespace Microsoft.AspNet.Identity.Test
         {
             public string Name { get; } = "Static";
 
-            public Task<string> GenerateAsync(string purpose, UserManager<TUser> manager, TUser user)
+            public async Task<string> GenerateAsync(string purpose, UserManager<TUser> manager, TUser user)
             {
-                return Task.FromResult(MakeToken(purpose, user));
+                return MakeToken(purpose, await manager.GetUserIdAsync(user));
             }
 
-            public Task<bool> ValidateAsync(string purpose, string token, UserManager<TUser> manager, TUser user)
+            public async Task<bool> ValidateAsync(string purpose, string token, UserManager<TUser> manager, TUser user)
             {
-                return Task.FromResult(token == MakeToken(purpose, user));
+                return token == MakeToken(purpose, await manager.GetUserIdAsync(user));
             }
 
             public Task NotifyAsync(string token, UserManager<TUser> manager, TUser user)
@@ -630,9 +639,9 @@ namespace Microsoft.AspNet.Identity.Test
                 return Task.FromResult(true);
             }
 
-            private static string MakeToken(string purpose, TUser user)
+            private static string MakeToken(string purpose, string userId)
             {
-                return string.Join(":", user.Id, purpose, "ImmaToken");
+                return string.Join(":", userId, purpose, "ImmaToken");
             }
         }
 
@@ -646,16 +655,17 @@ namespace Microsoft.AspNet.Identity.Test
             const string password = "password";
             const string newPassword = "newpassword";
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, password));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             var token = await manager.GeneratePasswordResetTokenAsync(user);
             Assert.NotNull(token);
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GeneratePasswordResetTokenAsync", user.Id.ToString());
+            var userId = await manager.GetUserIdAsync(user);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GeneratePasswordResetTokenAsync", userId);
             IdentityResultAssert.IsSuccess(await manager.ResetPasswordAsync(user, token, newPassword));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ResetPasswordAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ResetPasswordAsync", userId);
             Assert.False(await manager.CheckPasswordAsync(user, password));
             Assert.True(await manager.CheckPasswordAsync(user, newPassword));
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -668,16 +678,16 @@ namespace Microsoft.AspNet.Identity.Test
             const string password = "password";
             const string newPassword = "newpassword";
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, password));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             var token = await manager.GeneratePasswordResetTokenAsync(user);
             Assert.NotNull(token);
             manager.PasswordValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.ResetPasswordAsync(user, token, newPassword),
                 AlwaysBadValidator.ErrorMessage);
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ResetPasswordAsync", user.Id.ToString(), AlwaysBadValidator.ErrorMessage);
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ResetPasswordAsync", await manager.GetUserIdAsync(user), AlwaysBadValidator.ErrorMessage);
             Assert.True(await manager.CheckPasswordAsync(user, password));
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -690,12 +700,12 @@ namespace Microsoft.AspNet.Identity.Test
             const string password = "password";
             const string newPassword = "newpassword";
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, password));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             IdentityResultAssert.IsFailure(await manager.ResetPasswordAsync(user, "bogus", newPassword), "Invalid token.");
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ResetPasswordAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ResetPasswordAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.InvalidToken());
             Assert.True(await manager.CheckPasswordAsync(user, password));
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -707,15 +717,16 @@ namespace Microsoft.AspNet.Identity.Test
             var user2 = CreateTestUser();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user2));
+            var userId = await manager.GetUserIdAsync(user);
             var token = await manager.GenerateUserTokenAsync(user, "Static", "test");
             var expectedLog = string.Format("{0} : {1}", "GenerateUserTokenAsync", "Succeeded");
             IdentityResultAssert.VerifyLogMessage(manager.Logger, expectedLog);
 
             Assert.True(await manager.VerifyUserTokenAsync(user, "Static", "test", token));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "VerifyUserTokenAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "VerifyUserTokenAsync", userId);
 
             Assert.False(await manager.VerifyUserTokenAsync(user, "Static", "test2", token));
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyUserTokenAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyUserTokenAsync", userId, IdentityErrorDescriber.Default.InvalidToken());
 
             Assert.False(await manager.VerifyUserTokenAsync(user, "Static", "test", token + "a"));
             Assert.False(await manager.VerifyUserTokenAsync(user2, "Static", "test", token));
@@ -728,13 +739,14 @@ namespace Microsoft.AspNet.Identity.Test
             manager.RegisterTokenProvider(new StaticTokenProvider());
             manager.Options.EmailConfirmationTokenProvider = "Static";
             var user = CreateTestUser();
-            Assert.False(user.EmailConfirmed);
+            Assert.False(await manager.IsEmailConfirmedAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             var token = await manager.GenerateEmailConfirmationTokenAsync(user);
             Assert.NotNull(token);
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GenerateEmailConfirmationTokenAsync", user.Id.ToString());
+            var userId = await manager.GetUserIdAsync(user);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GenerateEmailConfirmationTokenAsync", userId);
             IdentityResultAssert.IsSuccess(await manager.ConfirmEmailAsync(user, token));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ConfirmEmailAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ConfirmEmailAsync", userId);
             Assert.True(await manager.IsEmailConfirmedAsync(user));
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, null));
             Assert.False(await manager.IsEmailConfirmedAsync(user));
@@ -747,19 +759,19 @@ namespace Microsoft.AspNet.Identity.Test
             manager.RegisterTokenProvider(new StaticTokenProvider());
             manager.Options.EmailConfirmationTokenProvider = "Static";
             var user = CreateTestUser();
-            Assert.False(user.EmailConfirmed);
+            Assert.False(await manager.IsEmailConfirmedAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             IdentityResultAssert.IsFailure(await manager.ConfirmEmailAsync(user, "bogus"), "Invalid token.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ConfirmEmailAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ConfirmEmailAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.InvalidToken());
         }
 
         [Fact]
         public async Task ConfirmTokenFailsAfterPasswordChange()
         {
             var manager = CreateManager();
-            var user = new TUser() { UserName = "test" };
-            Assert.False(user.EmailConfirmed);
+            var user = CreateTestUser(namePrefix: "Test");
+            Assert.False(await manager.IsEmailConfirmedAsync(user));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user, "password"));
             var token = await manager.GenerateEmailConfirmationTokenAsync(user);
             Assert.NotNull(token);
@@ -780,7 +792,6 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             Assert.False(await mgr.IsLockedOutAsync(user));
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.True(await mgr.IsLockedOutAsync(user));
@@ -798,7 +809,6 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             Assert.False(await mgr.IsLockedOutAsync(user));
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.False(await mgr.IsLockedOutAsync(user));
@@ -820,14 +830,13 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             Assert.False(await mgr.IsLockedOutAsync(user));
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
             Assert.False(await mgr.IsLockedOutAsync(user));
             Assert.False(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
             Assert.Equal(1, await mgr.GetAccessFailedCountAsync(user));
             IdentityResultAssert.IsSuccess(await mgr.ResetAccessFailedCountAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "ResetAccessFailedCountAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "ResetAccessFailedCountAsync", await mgr.GetUserIdAsync(user));
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
             Assert.False(await mgr.IsLockedOutAsync(user));
             Assert.False(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
@@ -846,14 +855,12 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.False(await mgr.GetLockoutEnabledAsync(user));
-            Assert.False(user.LockoutEnabled);
             IdentityResultAssert.IsSuccess(await mgr.SetLockoutEnabledAsync(user, true));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
-            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "SetLockoutEnabledAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "SetLockoutEnabledAsync", await mgr.GetUserIdAsync(user));
             Assert.False(await mgr.IsLockedOutAsync(user));
             IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "AccessFailedAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "AccessFailedAsync", await mgr.GetUserIdAsync(user));
             Assert.False(await mgr.IsLockedOutAsync(user));
             Assert.False(await mgr.GetLockoutEndDateAsync(user) > DateTimeOffset.UtcNow.AddMinutes(55));
             Assert.Equal(1, await mgr.GetAccessFailedCountAsync(user));
@@ -871,12 +878,10 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             IdentityResultAssert.IsSuccess(await mgr.SetLockoutEndDateAsync(user, new DateTimeOffset()));
             Assert.False(await mgr.IsLockedOutAsync(user));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "SetLockoutEndDateAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(mgr.Logger, "SetLockoutEndDateAsync", await mgr.GetUserIdAsync(user));
             Assert.Equal(new DateTimeOffset(), await mgr.GetLockoutEndDateAsync(user));
-            Assert.Equal(new DateTimeOffset(), user.LockoutEnd);
         }
 
         [Fact]
@@ -886,7 +891,6 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.False(await mgr.GetLockoutEnabledAsync(user));
-            Assert.False(user.LockoutEnabled);
             IdentityResultAssert.IsFailure(await mgr.SetLockoutEndDateAsync(user, new DateTimeOffset()),
                 "Lockout is not enabled for this user.");
             Assert.False(await mgr.IsLockedOutAsync(user));
@@ -897,11 +901,9 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.EnabledByDefault = true;
-            var user = CreateTestUser();
-            user.LockoutEnd = DateTimeOffset.UtcNow.AddSeconds(-1);
+            var user = CreateTestUser(lockoutEnd: DateTimeOffset.UtcNow.AddSeconds(-1));
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
 
@@ -913,7 +915,6 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             IdentityResultAssert.IsSuccess(await mgr.SetLockoutEndDateAsync(user, DateTimeOffset.UtcNow.AddSeconds(-1)));
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
@@ -923,11 +924,10 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.EnabledByDefault = true;
-            var user = CreateTestUser();
-            user.LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(5);
+            var lockoutEnd = DateTimeOffset.UtcNow.AddMinutes(5);
+            var user = CreateTestUser(lockoutEnd: lockoutEnd);
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             Assert.True(await mgr.IsLockedOutAsync(user));
         }
 
@@ -939,7 +939,6 @@ namespace Microsoft.AspNet.Identity.Test
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
-            Assert.True(user.LockoutEnabled);
             var lockoutEnd = new DateTimeOffset(DateTime.Now.AddMinutes(30).ToLocalTime());
             IdentityResultAssert.IsSuccess(await mgr.SetLockoutEndDateAsync(user, lockoutEnd));
             Assert.True(await mgr.IsLockedOutAsync(user));
@@ -952,10 +951,11 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanCreateRoleTest()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("create");
-            Assert.False(await manager.RoleExistsAsync(role.Name));
+            var roleName = "create" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
-            Assert.True(await manager.RoleExistsAsync(role.Name));
+            Assert.True(await manager.RoleExistsAsync(roleName));
         }
 
         private class AlwaysBadValidator : IUserValidator<TUser>, IRoleValidator<TRole>,
@@ -985,7 +985,7 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateRoleManager();
             manager.RoleValidators.Clear();
             manager.RoleValidators.Add(new AlwaysBadValidator());
-            IdentityResultAssert.IsFailure(await manager.CreateAsync(CreateRole("blocked")),
+            IdentityResultAssert.IsFailure(await manager.CreateAsync(CreateTestRole("blocked")),
                 AlwaysBadValidator.ErrorMessage);
         }
 
@@ -996,7 +996,7 @@ namespace Microsoft.AspNet.Identity.Test
             manager.RoleValidators.Clear();
             manager.RoleValidators.Add(new AlwaysBadValidator());
             manager.RoleValidators.Add(new AlwaysBadValidator());
-            var result = await manager.CreateAsync(CreateRole("blocked"));
+            var result = await manager.CreateAsync(CreateTestRole("blocked"));
             IdentityResultAssert.IsFailure(result, AlwaysBadValidator.ErrorMessage);
             Assert.Equal(2, result.Errors.Count());
         }
@@ -1005,39 +1005,41 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task BadValidatorBlocksRoleUpdate()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("poorguy");
+            var role = CreateTestRole("poorguy");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
             var error = AlwaysBadValidator.ErrorMessage;
             manager.RoleValidators.Clear();
             manager.RoleValidators.Add(new AlwaysBadValidator());
             IdentityResultAssert.IsFailure(await manager.UpdateAsync(role), error);
-            IdentityResultAssert.VerifyRoleManagerFailureLog(manager.Logger, "UpdateAsync", role.Id.ToString(), AlwaysBadValidator.ErrorMessage);
+            IdentityResultAssert.VerifyRoleManagerFailureLog(manager.Logger, "UpdateAsync", await manager.GetRoleIdAsync(role), AlwaysBadValidator.ErrorMessage);
         }
 
         [Fact]
         public async Task CanDeleteRole()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("delete");
-            Assert.False(await manager.RoleExistsAsync(role.Name));
+            var roleName = "delete" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
+            Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
+            Assert.True(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.DeleteAsync(role));
-            Assert.False(await manager.RoleExistsAsync(role.Name));
-            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "DeleteAsync", role.Id.ToString());
+            Assert.False(await manager.RoleExistsAsync(roleName));
+            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "DeleteAsync", await manager.GetRoleIdAsync(role));
         }
 
         [Fact]
         public async Task CanAddRemoveRoleClaim()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("ClaimsAddRemove");
+            var role = CreateTestRole("ClaimsAddRemove");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
             Claim[] claims = { new Claim("c", "v"), new Claim("c2", "v2"), new Claim("c2", "v3") };
             foreach (Claim c in claims)
             {
                 IdentityResultAssert.IsSuccess(await manager.AddClaimAsync(role, c));
             }
-            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "AddClaimAsync", role.Id.ToString());
+            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "AddClaimAsync", await manager.GetRoleIdAsync(role));
             var roleClaims = await manager.GetClaimsAsync(role);
             Assert.Equal(3, roleClaims.Count);
             IdentityResultAssert.IsSuccess(await manager.RemoveClaimAsync(role, claims[0]));
@@ -1050,41 +1052,43 @@ namespace Microsoft.AspNet.Identity.Test
             roleClaims = await manager.GetClaimsAsync(role);
             Assert.Equal(0, roleClaims.Count);
 
-            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "RemoveClaimAsync", role.Id.ToString());
+            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "RemoveClaimAsync", await manager.GetRoleIdAsync(role));
         }
 
         [Fact]
         public async Task CanRoleFindById()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("FindByIdAsync");
-            Assert.Null(await manager.FindByIdAsync(role.Id.ToString()));
+            var role = CreateTestRole("FindByIdAsync");
+            Assert.Null(await manager.FindByIdAsync(await manager.GetRoleIdAsync(role)));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
-            Assert.Equal(role, await manager.FindByIdAsync(role.Id.ToString()));
+            Assert.Equal(role, await manager.FindByIdAsync(await manager.GetRoleIdAsync(role)));
         }
 
         [Fact]
         public async Task CanRoleFindByName()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("FindByNameAsync");
-            Assert.Null(await manager.FindByNameAsync(role.Name));
-            Assert.False(await manager.RoleExistsAsync(role.Name));
+            var roleName = "FindByNameAsync" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.Null(await manager.FindByNameAsync(roleName));
+            Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
-            Assert.Equal(role, await manager.FindByNameAsync(role.Name));
+            Assert.Equal(role, await manager.FindByNameAsync(roleName));
         }
 
         [Fact]
         public async Task CanUpdateRoleName()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("update");
-            Assert.False(await manager.RoleExistsAsync(role.Name));
+            var roleName = "update" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
-            Assert.True(await manager.RoleExistsAsync(role.Name));
+            Assert.True(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.SetRoleNameAsync(role, "Changed"));
             IdentityResultAssert.IsSuccess(await manager.UpdateAsync(role));
-            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "UpdateAsync", role.Id.ToString());
+            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "UpdateAsync", await manager.GetRoleIdAsync(role));
             Assert.False(await manager.RoleExistsAsync("update"));
             Assert.Equal(role, await manager.FindByNameAsync("Changed"));
         }
@@ -1093,39 +1097,44 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CanQueryableRoles()
         {
             var manager = CreateRoleManager();
-            var roles = GenerateRoles("CanQuerableRolesTest", 4);
-            foreach (var r in roles)
+            if (manager.SupportsQueryableRoles)
             {
-                IdentityResultAssert.IsSuccess(await manager.CreateAsync(r));
+                var roles = GenerateRoles("CanQuerableRolesTest", 4);
+                foreach (var r in roles)
+                {
+                    IdentityResultAssert.IsSuccess(await manager.CreateAsync(r));
+                }
+                Assert.Equal(roles.Count, manager.Roles.Count(RoleNameStartsWithPredicate("CanQuerableRolesTest")));
+                var r1 = manager.Roles.FirstOrDefault(RoleNameStartsWithPredicate("CanQuerableRolesTest1"));
+                Assert.Equal(roles[1], r1);
             }
-            Assert.Equal(roles.Count, manager.Roles.Count(r => r.Name.StartsWith("CanQuerableRolesTest")));
-            var r1 = manager.Roles.FirstOrDefault(r => r.Name.StartsWith("CanQuerableRolesTest1"));
-            Assert.Equal(roles[1], r1);
         }
 
-        [Fact]
+        // Enable when delete on cascade is supported in EF
+        // [Fact]
         public async Task DeleteRoleNonEmptySucceedsTest()
         {
             // Need fail if not empty?
             var context = CreateTestContext();
             var userMgr = CreateManager(context);
             var roleMgr = CreateRoleManager(context);
-            var role = CreateRole();
-            Assert.False(await roleMgr.RoleExistsAsync(role.Name));
+            var roleName = "delete" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
+            Assert.False(await roleMgr.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
-            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, role.Name));
+            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
             var roles = await userMgr.GetRolesAsync(user);
             Assert.Equal(1, roles.Count());
             IdentityResultAssert.IsSuccess(await roleMgr.DeleteAsync(role));
-            Assert.Null(await roleMgr.FindByNameAsync(role.Name));
-            Assert.False(await roleMgr.RoleExistsAsync(role.Name));
+            Assert.Null(await roleMgr.FindByNameAsync(roleName));
+            Assert.False(await roleMgr.RoleExistsAsync(roleName));
             // REVIEW: We should throw if deleteing a non empty role?
             roles = await userMgr.GetRolesAsync(user);
 
             // REVIEW: This depends on cascading deletes
-            //Assert.Equal(0, roles.Count());
+            Assert.Equal(0, roles.Count());
         }
 
         // TODO: cascading deletes?  navigation properties not working
@@ -1136,11 +1145,11 @@ namespace Microsoft.AspNet.Identity.Test
         ////    var userMgr = CreateManager();
         ////    var roleMgr = CreateRoleManager();
         ////    var role = CreateRole("deleteNonEmpty");
-        ////    Assert.False(await roleMgr.RoleExistsAsync(role.Name));
+        ////    Assert.False(await roleMgr.RoleExistsAsync(roleName));
         ////    IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
         ////    var user = new TUser() { UserName = "t");
         ////    IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
-        ////    IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, role.Name));
+        ////    IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
         ////    IdentityResultAssert.IsSuccess(await userMgr.DeleteAsync(user));
         ////    role = roleMgr.FindByIdAsync(role.Id);
         ////}
@@ -1149,13 +1158,13 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task CreateRoleFailsIfExists()
         {
             var manager = CreateRoleManager();
-            var role = CreateRole("dupeRole");
-            Assert.False(await manager.RoleExistsAsync(role.Name));
+            var roleName = "dupeRole" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
-            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "CreateAsync", role.Id.ToString());
-            Assert.True(await manager.RoleExistsAsync(role.Name));
-            var role2 = CreateRole();
-            role2.Name = role.Name;
+            IdentityResultAssert.VerifyRoleManagerSuccessLog(manager.Logger, "CreateAsync", await manager.GetRoleIdAsync(role));
+            Assert.True(await manager.RoleExistsAsync(roleName));
+            var role2 = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             IdentityResultAssert.IsFailure(await manager.CreateAsync(role2));
         }
 
@@ -1165,19 +1174,19 @@ namespace Microsoft.AspNet.Identity.Test
             var context = CreateTestContext();
             var manager = CreateManager(context);
             var roleManager = CreateRoleManager(context);
-            var role = CreateRole("addUserTest");
+            var roleName = "AddUserTest" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(role));
             TUser[] users =
             {
-                new TUser() { UserName = "1"}, new TUser() { UserName = "2"}, new TUser() { UserName = "3"},
-                new TUser() { UserName = "4"}
+                CreateTestUser("1"),CreateTestUser("2"),CreateTestUser("3"),CreateTestUser("4"),
             };
             foreach (var u in users)
             {
                 IdentityResultAssert.IsSuccess(await manager.CreateAsync(u));
-                IdentityResultAssert.IsSuccess(await manager.AddToRoleAsync(u, role.Name));
-                Assert.True(await manager.IsInRoleAsync(u, role.Name));
-                IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddToRoleAsync", u.Id.ToString());
+                IdentityResultAssert.IsSuccess(await manager.AddToRoleAsync(u, roleName));
+                Assert.True(await manager.IsInRoleAsync(u, roleName));
+                IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddToRoleAsync", await manager.GetUserIdAsync(u));
 
             }
         }
@@ -1199,8 +1208,8 @@ namespace Microsoft.AspNet.Identity.Test
                 IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(r));
                 foreach (var u in users)
                 {
-                    IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(u, r.Name));
-                    Assert.True(await userManager.IsInRoleAsync(u, r.Name));
+                    IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
+                    Assert.True(await userManager.IsInRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
                 }
             }
 
@@ -1210,7 +1219,8 @@ namespace Microsoft.AspNet.Identity.Test
                 Assert.Equal(roles.Count, rs.Count);
                 foreach (var r in roles)
                 {
-                    Assert.True(rs.Any(role => role == r.Name));
+                    var expectedRoleName = await roleManager.GetRoleNameAsync(r);
+                    Assert.True(rs.Any(role => role == expectedRoleName));
                 }
             }
         }
@@ -1227,12 +1237,12 @@ namespace Microsoft.AspNet.Identity.Test
             foreach (var r in roles)
             {
                 IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(r));
-                IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(user, r.Name));
-                Assert.True(await userManager.IsInRoleAsync(user, r.Name));
+                IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(user, await roleManager.GetRoleNameAsync(r)));
+                Assert.True(await userManager.IsInRoleAsync(user, await roleManager.GetRoleNameAsync(r)));
             }
-            IdentityResultAssert.IsSuccess(await userManager.RemoveFromRoleAsync(user, roles[2].Name));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(userManager.Logger, "RemoveFromRoleAsync", user.Id.ToString());
-            Assert.False(await userManager.IsInRoleAsync(user, roles[2].Name));
+            IdentityResultAssert.IsSuccess(await userManager.RemoveFromRoleAsync(user, await roleManager.GetRoleNameAsync(roles[2])));
+            IdentityResultAssert.VerifyUserManagerSuccessLog(userManager.Logger, "RemoveFromRoleAsync", await userManager.GetUserIdAsync(user));
+            Assert.False(await userManager.IsInRoleAsync(user, await roleManager.GetRoleNameAsync(roles[2])));
         }
 
         [Fact]
@@ -1246,17 +1256,17 @@ namespace Microsoft.AspNet.Identity.Test
             {
                 IdentityResultAssert.IsSuccess(await userManager.CreateAsync(u));
             }
-            var r = CreateRole("r1");
+            var r = CreateTestRole("r1");
             IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(r));
             foreach (var u in users)
             {
-                IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(u, r.Name));
-                Assert.True(await userManager.IsInRoleAsync(u, r.Name));
+                IdentityResultAssert.IsSuccess(await userManager.AddToRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
+                Assert.True(await userManager.IsInRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
             }
             foreach (var u in users)
             {
-                IdentityResultAssert.IsSuccess(await userManager.RemoveFromRoleAsync(u, r.Name));
-                Assert.False(await userManager.IsInRoleAsync(u, r.Name));
+                IdentityResultAssert.IsSuccess(await userManager.RemoveFromRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
+                Assert.False(await userManager.IsInRoleAsync(u, await roleManager.GetRoleNameAsync(r)));
             }
         }
 
@@ -1266,13 +1276,14 @@ namespace Microsoft.AspNet.Identity.Test
             var context = CreateTestContext();
             var userMgr = CreateManager(context);
             var roleMgr = CreateRoleManager(context);
-            var role = CreateRole("addUserDupeTest");
+            var roleName = "addUserDupeTest" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-            var result = await userMgr.RemoveFromRoleAsync(user, role.Name);
-            IdentityResultAssert.IsFailure(result, IdentityErrorDescriber.Default.UserNotInRole(role.Name));
-            IdentityResultAssert.VerifyUserManagerFailureLog(userMgr.Logger, "RemoveFromRoleAsync", user.Id.ToString(), IdentityErrorDescriber.Default.UserNotInRole(role.Name));
+            var result = await userMgr.RemoveFromRoleAsync(user, roleName);
+            IdentityResultAssert.IsFailure(result, IdentityErrorDescriber.Default.UserNotInRole(roleName));
+            IdentityResultAssert.VerifyUserManagerFailureLog(userMgr.Logger, "RemoveFromRoleAsync", await userMgr.GetUserIdAsync(user), IdentityErrorDescriber.Default.UserNotInRole(roleName));
         }
 
         [Fact]
@@ -1281,88 +1292,87 @@ namespace Microsoft.AspNet.Identity.Test
             var context = CreateTestContext();
             var userMgr = CreateManager(context);
             var roleMgr = CreateRoleManager(context);
-            var role = CreateRole("addUserDupeTest");
+            var roleName = "addUserDupeTest" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, role.Name));
-            Assert.True(await userMgr.IsInRoleAsync(user, role.Name));
-            IdentityResultAssert.IsFailure(await userMgr.AddToRoleAsync(user, role.Name), IdentityErrorDescriber.Default.UserAlreadyInRole(role.Name));
-            IdentityResultAssert.VerifyUserManagerFailureLog(userMgr.Logger, "AddToRoleAsync", user.Id.ToString(), IdentityErrorDescriber.Default.UserAlreadyInRole(role.Name));
+            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
+            Assert.True(await userMgr.IsInRoleAsync(user, roleName));
+            IdentityResultAssert.IsFailure(await userMgr.AddToRoleAsync(user, roleName), IdentityErrorDescriber.Default.UserAlreadyInRole(roleName));
+            IdentityResultAssert.VerifyUserManagerFailureLog(userMgr.Logger, "AddToRoleAsync", await userMgr.GetUserIdAsync(user), IdentityErrorDescriber.Default.UserAlreadyInRole(roleName));
         }
 
         [Fact]
         public async Task CanFindRoleByNameWithManager()
         {
             var roleMgr = CreateRoleManager();
-            var role = CreateRole("findRoleByNameTest");
+            var roleName = "findRoleByNameTest" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-            Assert.Equal(role.Id, (await roleMgr.FindByNameAsync(role.Name)).Id);
+            Assert.NotNull(await roleMgr.FindByNameAsync(roleName));
         }
 
         [Fact]
         public async Task CanFindRoleWithManager()
         {
             var roleMgr = CreateRoleManager();
-            var role = CreateRole("findRoleTest");
+            var roleName = "findRoleTest" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-            Assert.Equal(role.Name, (await roleMgr.FindByIdAsync(role.Id.ToString())).Name);
+            Assert.Equal(roleName, await roleMgr.GetRoleNameAsync(await roleMgr.FindByNameAsync(roleName)));
         }
 
         [Fact]
         public async Task SetPhoneNumberTest()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "123-456-7890";
+            var user = CreateTestUser(phoneNumber: "123-456-7890");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
             Assert.Equal(await manager.GetPhoneNumberAsync(user), "123-456-7890");
             IdentityResultAssert.IsSuccess(await manager.SetPhoneNumberAsync(user, "111-111-1111"));
             Assert.Equal(await manager.GetPhoneNumberAsync(user), "111-111-1111");
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task CanChangePhoneNumber()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "123-456-7890";
+            var user = CreateTestUser(phoneNumber: "123-456-7890");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
             var token1 = await manager.GenerateChangePhoneNumberTokenAsync(user, "111-111-1111");
             IdentityResultAssert.IsSuccess(await manager.ChangePhoneNumberAsync(user, "111-111-1111", token1));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangePhoneNumberAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangePhoneNumberAsync", await manager.GetUserIdAsync(user));
             Assert.True(await manager.IsPhoneNumberConfirmedAsync(user));
             Assert.Equal(await manager.GetPhoneNumberAsync(user), "111-111-1111");
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task ChangePhoneNumberFailsWithWrongToken()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "123-456-7890";
+            var user = CreateTestUser(phoneNumber: "123-456-7890");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
             IdentityResultAssert.IsFailure(await manager.ChangePhoneNumberAsync(user, "111-111-1111", "bogus"),
                 "Invalid token.");
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePhoneNumberAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangePhoneNumberAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.InvalidToken());
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             Assert.Equal(await manager.GetPhoneNumberAsync(user), "123-456-7890");
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task ChangePhoneNumberFailsWithWrongPhoneNumber()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "123-456-7890";
+            var user = CreateTestUser(phoneNumber: "123-456-7890");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
@@ -1371,7 +1381,7 @@ namespace Microsoft.AspNet.Identity.Test
                 "Invalid token.");
             Assert.False(await manager.IsPhoneNumberConfirmedAsync(user));
             Assert.Equal(await manager.GetPhoneNumberAsync(user), "123-456-7890");
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -1382,63 +1392,67 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             const string num1 = "111-123-4567";
             const string num2 = "111-111-1111";
+            var userId = await manager.GetUserIdAsync(user);
             var token1 = await manager.GenerateChangePhoneNumberTokenAsync(user, num1);
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GenerateChangePhoneNumberTokenAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "GenerateChangePhoneNumberTokenAsync", userId);
 
             var token2 = await manager.GenerateChangePhoneNumberTokenAsync(user, num2);
             Assert.NotEqual(token1, token2);
             Assert.True(await manager.VerifyChangePhoneNumberTokenAsync(user, token1, num1));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "VerifyChangePhoneNumberTokenAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "VerifyChangePhoneNumberTokenAsync", userId);
             Assert.True(await manager.VerifyChangePhoneNumberTokenAsync(user, token2, num2));
             Assert.False(await manager.VerifyChangePhoneNumberTokenAsync(user, token2, num1));
             Assert.False(await manager.VerifyChangePhoneNumberTokenAsync(user, token1, num2));
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyChangePhoneNumberTokenAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyChangePhoneNumberTokenAsync", userId, IdentityErrorDescriber.Default.InvalidToken());
         }
 
         [Fact]
         public async Task CanChangeEmail()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.Email = user.UserName + "@diddly.bop";
+            var user = CreateTestUser("foouser");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            var email = await manager.GetUserNameAsync(user) + "@diddly.bop";
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, email));
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
-            string newEmail = user.UserName + "@en.vec";
+            var newEmail = await manager.GetUserNameAsync(user) + "@en.vec";
             var token1 = await manager.GenerateChangeEmailTokenAsync(user, newEmail);
             IdentityResultAssert.IsSuccess(await manager.ChangeEmailAsync(user, newEmail, token1));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangeEmailAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "ChangeEmailAsync", await manager.GetUserIdAsync(user));
             Assert.True(await manager.IsEmailConfirmedAsync(user));
             Assert.Equal(await manager.GetEmailAsync(user), newEmail);
-            Assert.NotEqual(stamp, user.SecurityStamp);
+            Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task ChangeEmailFailsWithWrongToken()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.Email = user.UserName + "@diddly.bop";
-            string oldEmail = user.Email;
+            var user = CreateTestUser("foouser");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            var email = await manager.GetUserNameAsync(user) + "@diddly.bop";
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, email));
+            string oldEmail = email;
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
             IdentityResultAssert.IsFailure(await manager.ChangeEmailAsync(user, "whatevah@foo.barf", "bogus"),
                 "Invalid token.");
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangeEmailAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "ChangeEmailAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.InvalidToken());
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             Assert.Equal(await manager.GetEmailAsync(user), oldEmail);
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
         public async Task ChangeEmailFailsWithEmail()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.Email = user.UserName + "@diddly.bop";
-            string oldEmail = user.Email;
+            var user = CreateTestUser("foouser");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            var email = await manager.GetUserNameAsync(user) + "@diddly.bop";
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, email));
+            string oldEmail = email;
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             var stamp = await manager.GetSecurityStampAsync(user);
             var token1 = await manager.GenerateChangeEmailTokenAsync(user, "forgot@alrea.dy");
@@ -1446,7 +1460,7 @@ namespace Microsoft.AspNet.Identity.Test
                 "Invalid token.");
             Assert.False(await manager.IsEmailConfirmedAsync(user));
             Assert.Equal(await manager.GetEmailAsync(user), oldEmail);
-            Assert.Equal(stamp, user.SecurityStamp);
+            Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
         [Fact]
@@ -1454,13 +1468,16 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             string factorId = "Email"; //default
-            var user = CreateTestUser();
-            user.Email = user.UserName + "@foo.com";
-            user.EmailConfirmed = true;
+            var user = CreateTestUser("foouser");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            var stamp = user.SecurityStamp;
+            var email = await manager.GetUserNameAsync(user) + "@diddly.bop";
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, email));
+            var token = await manager.GenerateEmailConfirmationTokenAsync(user);
+            await manager.ConfirmEmailAsync(user, token);
+
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
-            var token = await manager.GenerateTwoFactorTokenAsync(user, factorId);
+            token = await manager.GenerateTwoFactorTokenAsync(user, factorId);
             Assert.NotNull(token);
             IdentityResultAssert.IsSuccess(await manager.UpdateSecurityStampAsync(user));
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, factorId, token));
@@ -1472,10 +1489,10 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateManager();
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             IdentityResultAssert.IsSuccess(await manager.SetTwoFactorEnabledAsync(user, true));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetTwoFactorEnabledAsync", user.Id.ToString());
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetTwoFactorEnabledAsync", await manager.GetUserIdAsync(user));
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
             Assert.True(await manager.GetTwoFactorEnabledAsync(user));
         }
@@ -1511,21 +1528,23 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateManager();
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            var userId = await manager.GetUserIdAsync(user);
             var factors = await manager.GetValidTwoFactorProvidersAsync(user);
             Assert.NotNull(factors);
             Assert.False(factors.Any());
             IdentityResultAssert.IsSuccess(await manager.SetPhoneNumberAsync(user, "111-111-1111"));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetPhoneNumberAsync", user.Id.ToString());
-            user.PhoneNumberConfirmed = true;
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetPhoneNumberAsync", userId);
+            var token = await manager.GenerateChangePhoneNumberTokenAsync(user, "111-111-1111");
+            IdentityResultAssert.IsSuccess(await manager.ChangePhoneNumberAsync(user, "111-111-1111", token));
             await manager.UpdateAsync(user);
             factors = await manager.GetValidTwoFactorProvidersAsync(user);
             Assert.NotNull(factors);
             Assert.Equal(1, factors.Count());
             Assert.Equal("Phone", factors[0]);
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, "test@test.com"));
-            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetEmailAsync", user.Id.ToString());
-            user.EmailConfirmed = true;
-            await manager.UpdateAsync(user);
+            IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "SetEmailAsync", userId);
+            token = await manager.GenerateEmailConfirmationTokenAsync(user);
+            await manager.ConfirmEmailAsync(user, token);
             factors = await manager.GetValidTwoFactorProvidersAsync(user);
             Assert.NotNull(factors);
             Assert.Equal(2, factors.Count());
@@ -1541,10 +1560,9 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateManager();
             var factorId = "Phone"; // default
-            var user = CreateTestUser();
-            user.PhoneNumber = "4251234567";
+            var user = CreateTestUser(phoneNumber: "4251234567");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
-            var stamp = user.SecurityStamp;
+            var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
             var token = await manager.GenerateTwoFactorTokenAsync(user, factorId);
             Assert.NotNull(token);
@@ -1556,8 +1574,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task VerifyTokenFromWrongTokenProviderFails()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "4251234567";
+            var user = CreateTestUser(phoneNumber: "4251234567");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             var token = await manager.GenerateTwoFactorTokenAsync(user, "Phone");
             Assert.NotNull(token);
@@ -1568,19 +1585,17 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task VerifyWithWrongSmsTokenFails()
         {
             var manager = CreateManager();
-            var user = CreateTestUser();
-            user.PhoneNumber = "4251234567";
+            var user = CreateTestUser(phoneNumber: "4251234567");
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.False(await manager.VerifyTwoFactorTokenAsync(user, "Phone", "bogus"));
-            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyTwoFactorTokenAsync", user.Id.ToString(), IdentityErrorDescriber.Default.InvalidToken());
+            IdentityResultAssert.VerifyUserManagerFailureLog(manager.Logger, "VerifyTwoFactorTokenAsync", await manager.GetUserIdAsync(user), IdentityErrorDescriber.Default.InvalidToken());
         }
 
         [Fact]
         public async Task NullableDateTimeOperationTest()
         {
             var userMgr = CreateManager();
-            var user = CreateTestUser();
-            user.LockoutEnabled = true;
+            var user = CreateTestUser(lockoutEnabled: true);
             IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
 
             Assert.Null(await userMgr.GetLockoutEndDateAsync(user));
@@ -1622,10 +1637,12 @@ namespace Microsoft.AspNet.Identity.Test
             var manager = CreateManager(context);
             var roleManager = CreateRoleManager(context);
             var roles = GenerateRoles("UsersInRole", 4);
+            var roleNameList = new List<string>();
 
             foreach (var role in roles)
             {
                 IdentityResultAssert.IsSuccess(await roleManager.CreateAsync(role));
+                roleNameList.Add(await roleManager.GetRoleNameAsync(role));
             }
 
             for (int i = 0; i < 6; i++)
@@ -1635,14 +1652,14 @@ namespace Microsoft.AspNet.Identity.Test
 
                 if ((i % 2) == 0)
                 {
-                    IdentityResultAssert.IsSuccess(await manager.AddToRolesAsync(user, roles.Select(x => x.Name).AsEnumerable()));
-                    IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddToRolesAsync", user.Id.ToString());
+                    IdentityResultAssert.IsSuccess(await manager.AddToRolesAsync(user, roleNameList));
+                    IdentityResultAssert.VerifyUserManagerSuccessLog(manager.Logger, "AddToRolesAsync", await manager.GetUserIdAsync(user));
                 }
             }
 
             foreach (var role in roles)
             {
-                Assert.Equal(3, (await manager.GetUsersInRoleAsync(role.Name)).Count);
+                Assert.Equal(3, (await manager.GetUsersInRoleAsync(await roleManager.GetRoleNameAsync(role))).Count);
             }
 
             Assert.Equal(0, (await manager.GetUsersInRoleAsync("123456")).Count);
@@ -1663,7 +1680,7 @@ namespace Microsoft.AspNet.Identity.Test
             var roles = new List<TRole>(count);
             for (var i = 0; i < count; i++)
             {
-                roles.Add(CreateRole(namePrefix + i));
+                roles.Add(CreateTestRole(namePrefix + i));
             }
             return roles;
         }


### PR DESCRIPTION
@HaoK I moved the POCOs to Identity.EF. The Identity.Test and Identity.InMemory.Test broke due to this change since they did not reference Identity.EF. Now we could either duplicate the code in the tests or reference the assembly and include the namespace. In addition the UserManagerTestBase is shared so that has to updated also. I choose to reference the assembly as this seems more cleaner. I made sure we reference only the POCOs and nothing else. Let me know if there is a better way of doing this.

/cc @divega 

You can skip the nitpick feedback for this PR