### PR TITLE
Updating test projects to use xunit.runner.aspnet

### DIFF
--- a/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/project.json
@@ -10,7 +10,7 @@
     "EntityFramework.InMemory": "7.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
     "System.Security.Claims": "1.0.0-*",
-    "xunit.runner.kre": "1.0.0-*"
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "code": "**\\*.cs;..\\Shared\\*.cs",
   "frameworks": {
@@ -21,6 +21,6 @@
     }
   },
   "commands": {
-    "test": "xunit.runner.kre"
+    "test": "xunit.runner.aspnet"
   }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/project.json
@@ -11,7 +11,7 @@
     "EntityFramework.SqlServer": "7.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
     "System.Security.Claims": "1.0.0-*",
-    "xunit.runner.kre": "1.0.0-*"
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "code": "**\\*.cs;..\\Shared\\*.cs",
   "frameworks": {
@@ -22,6 +22,6 @@
     }
   },
   "commands": {
-    "test": "xunit.runner.kre"
+    "test": "xunit.runner.aspnet"
   }
 }

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/project.json
@@ -12,7 +12,7 @@
     "Microsoft.Framework.DependencyInjection" : "1.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
     "Moq": "4.2.1312.1622",
-    "xunit.runner.kre": "1.0.0-*"
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "code": "**\\*.cs;..\\Shared\\*.cs",
   "frameworks": {
@@ -23,6 +23,6 @@
     }
   },
   "commands": {
-    "test": "xunit.runner.kre"
+    "test": "xunit.runner.aspnet"
   }
 }

--- a/test/Microsoft.AspNet.Identity.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.Test/project.json
@@ -8,7 +8,7 @@
     "Microsoft.Framework.ConfigurationModel" : "1.0.0-*",
     "Microsoft.Framework.DependencyInjection" : "1.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
-    "xunit.runner.kre": "1.0.0-*"
+    "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "code": "**\\*.cs;..\\Shared\\*.cs",
   "frameworks": {
@@ -19,6 +19,6 @@
     }
   },
   "commands": {
-    "test": "xunit.runner.kre"
+    "test": "xunit.runner.aspnet"
   }
 }

--- a/test/Shared/PriorityOrderer.cs
+++ b/test/Shared/PriorityOrderer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Identity.Test
             {
                 int priority = 0;
 
-                foreach (IAttributeInfo attr in testCase.TestMethod.Method.GetCustomAttributes((typeof(TestPriorityAttribute))))
+                foreach (IAttributeInfo attr in testCase.TestMethod.Method.GetCustomAttributes((typeof(TestPriorityAttribute)).AssemblyQualifiedName))
                     priority = attr.GetNamedArgument<int>("Priority");
 
                 GetOrCreate(sortedMethods, priority).Add(testCase);


### PR DESCRIPTION
@divega @HaoK 

Changes
- Updating to use `xunit.runner.aspnet`
- Changing the `GetCustomAttributes` method to use `string` argument instead of `type` since that was causing conflicts due to two assemblies have the same extension method. This change resolves it since that's what the original method is doing internally.