### PR TITLE
Fix reset acces token

### DIFF
--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -1784,6 +1784,12 @@ namespace Microsoft.AspNet.Identity
             {
                 throw new ArgumentNullException("user");
             }
+
+            if (await GetAccessFailedCountAsync(user) == 0)
+            {
+                return IdentityResult.Success;
+            }
+
             await store.ResetAccessFailedCountAsync(user, CancellationToken);
             return await LogResultAsync(await UpdateUserAsync(user), user);
         }

--- a/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
@@ -628,6 +628,20 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         [Fact]
+        public async Task ResetTokenCallNoopForTokenValueZero()
+        {
+            var user = new IdentityUser() { UserName = Guid.NewGuid().ToString()};
+            var store = new Mock<IUserLockoutStore<IdentityUser>>();
+            store.Setup(x => x.ResetAccessFailedCountAsync(user, It.IsAny<CancellationToken>())).Returns(() =>
+               {
+                   throw new Exception();
+               });
+            var manager = MockHelpers.TestUserManager(store.Object);
+
+            IdentityResultAssert.IsSuccess(await manager.ResetAccessFailedCountAsync(user));
+        }
+
+        [Fact]
         public async Task ManagerPublicNullChecks()
         {
             Assert.Throws<ArgumentNullException>("store",


### PR DESCRIPTION
@HaoK 

Porting fix from 2.2 Adding test that verifies that store method is not called when the token value is zero. 

https://github.com/aspnet/Identity/issues/398