### PR TITLE
Set ViewBag.LoginProvider in error scenarios

### DIFF
--- a/samples/IdentitySample.Mvc/Controllers/AccountController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/AccountController.cs
@@ -199,6 +199,7 @@ namespace IdentitySample.Controllers
                     }
                 }
                 AddErrors(result);
+                ViewBag.LoginProvider = info.Login.LoginProvider;
             }
 
             ViewBag.ReturnUrl = returnUrl;


### PR DESCRIPTION
Failure to do so will leave certain fields blank in the view.