### PR TITLE
Add SQL Identity support

### DIFF
--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -26,6 +26,10 @@ namespace Microsoft.AspNet.Identity.EntityFramework
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
+            // Temporary change. 
+            // Can be reverted once https://github.com/aspnet/EntityFramework/issues/1960 is closed
+            builder.ForSqlServer().UseIdentity();
+
             builder.Entity<TUser>(b =>
                 {
                     b.Key(u => u.Id);

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
-            // Temporary change. 
+            // TODO: Temporary change. 
             // Can be reverted once https://github.com/aspnet/EntityFramework/issues/1960 is closed
             builder.ForSqlServer().UseIdentity();
 


### PR DESCRIPTION
Issue:
EF chose to use 'sequence' to generate PK values by default which is not supported in SQL Azure. This was causing templates to break functionally when published to Azure. It is being tracked for beta5 by the EF team aspnet/EntityFramework#1960

Fix:
As a workaround for beta4, we are adding the workaround in IdentityDbContext which should fix the issue for templates and music store. Apps that are started from empty template need to adds this in their DBContext class manually.

@divega @HaoK
