### PR TITLE
[Feedback] Include validation for set username/email methods

### DIFF
--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -128,15 +128,44 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         [Fact]
-        public async Task CanSetUserName()
+        public async Task CheckSetUserNameValidatesUser()
         {
             var manager = CreateManager();
-            var user = CreateTestUser("UpdateAsync");
+            manager.UserValidators.Add(new UserValidator<TUser>());
+            var username = "UpdateAsync" + Guid.NewGuid().ToString();
+            var newUsername = "New" + Guid.NewGuid().ToString();
+            var user = CreateTestUser(username, useNamePrefixAsUserName: true);
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             Assert.Null(await manager.FindByNameAsync("New"));
-            IdentityResultAssert.IsSuccess(await manager.SetUserNameAsync(user, "New"));
-            Assert.NotNull(await manager.FindByNameAsync("New"));
-            Assert.Null(await manager.FindByNameAsync("UpdateAsync"));
+            IdentityResultAssert.IsSuccess(await manager.SetUserNameAsync(user, newUsername));
+            Assert.NotNull(await manager.FindByNameAsync(newUsername));
+            Assert.Null(await manager.FindByNameAsync(username));
+
+            var newUser = CreateTestUser(username, useNamePrefixAsUserName: true);
+            IdentityResultAssert.IsSuccess(await manager.CreateAsync(newUser));
+            IdentityResultAssert.IsFailure(await manager.SetUserNameAsync(newUser, ""), IdentityErrorDescriber.Default.InvalidUserName(""));
+            IdentityResultAssert.IsFailure(await manager.SetUserNameAsync(newUser, newUsername), IdentityErrorDescriber.Default.DuplicateUserName(newUsername));
+            Assert.NotNull(await manager.FindByNameAsync(username));
+        }
+
+        [Fact]
+        public async Task CheckSetEmailValidatesUser()
+        {
+            var manager = CreateManager();
+            manager.Options.User.RequireUniqueEmail = true;
+            manager.UserValidators.Add(new UserValidator<TUser>());
+            var random = new Random();
+            var email = "foo" + random.Next() + "@example.com";
+            var newEmail = "foo" + random.Next() + "@example.com";
+            var user = CreateTestUser(email: email);
+            IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
+            IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, newEmail));
+
+            var newUser = CreateTestUser(email: email);
+            IdentityResultAssert.IsSuccess(await manager.CreateAsync(newUser));
+            IdentityResultAssert.IsFailure(await manager.SetEmailAsync(newUser, newEmail), IdentityErrorDescriber.Default.DuplicateEmail(newEmail));
+            IdentityResultAssert.IsFailure(await manager.SetEmailAsync(newUser, ""), IdentityErrorDescriber.Default.InvalidEmail(""));
+            Assert.NotNull(await manager.FindByEmailAsync(email));
         }
 
         [Fact]
@@ -1019,7 +1048,7 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var manager = CreateRoleManager();
             var roleName = "delete" + Guid.NewGuid().ToString();
-            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             Assert.False(await manager.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(role));
             Assert.True(await manager.RoleExistsAsync(roleName));
@@ -1118,7 +1147,7 @@ namespace Microsoft.AspNet.Identity.Test
             var userMgr = CreateManager(context);
             var roleMgr = CreateRoleManager(context);
             var roleName = "delete" + Guid.NewGuid().ToString();
-            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             Assert.False(await roleMgr.RoleExistsAsync(roleName));
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
             var user = CreateTestUser();
@@ -1276,7 +1305,7 @@ namespace Microsoft.AspNet.Identity.Test
             var userMgr = CreateManager(context);
             var roleMgr = CreateRoleManager(context);
             var roleName = "addUserDupeTest" + Guid.NewGuid().ToString();
-            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName:true);
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));


### PR DESCRIPTION
@HaoK @divega 

Issue:
The methods SetUserName/SetEmail do not call user validators when setting the username/email to new values. This seems to be like an issue and hence including that in this fix

Fix:
- In Set username/email methods call `ValidateUserInternal` once the username/email is set to the new value. If the validation succeeds, then continue else revert back to the old values
- Added two tests that test this operation. We try to set the username/email to empty and duplicate values and check if the validation succeeds

Question
- In the SetUsername we don't call UpdateSecurityStamp method. I think we should be doing it. Any reasons for not doing it right now ?

https://github.com/aspnet/Identity/issues/384 