### PR TITLE
[Feedback] Sample logging changes

### DIFF
--- a/src/Microsoft.AspNet.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNet.Identity/SignInManager.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNet.Identity
         /// Validates that the claims identity has a security stamp matching the users
         /// Returns the user if it matches, null otherwise
         /// </summary>
-        /// <param name="identity"></param>
+        /// <param name="principal"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
         public virtual async Task<TUser> ValidateSecurityStampAsync(ClaimsPrincipal principal, string userId)
@@ -402,7 +402,7 @@ namespace Microsoft.AspNet.Identity
                 Context.Response.SignOut(IdentityOptions.ExternalCookieAuthenticationScheme);
             }
             await SignInAsync(user, isPersistent, loginProvider);
-            if (Logger.IsEnabled(LogLevel.Information))
+            if (Logger.IsEnabled(LogLevel.Verbose))
             {
                 Logger.LogVerbose("User {userId} signin successful", await UserManager.GetUserIdAsync(user));
             }


### PR DESCRIPTION
@HaoK @divega 
I took a shot at the logging feedback post our meeting with @loudej . The full list of feedback is added to team one note

Some pivots I have used for the changes
* Replaced automated logging with readable statements
* All statements in English and no use of Resource file.
* Direct inplace logging with no extension methods
* check if log is enabled in places where we get the userid via await call only

Questions
* Do we want the logging statements to be of a standard format. for example `{operation} user: {userId}`. This might make it more searchable via patterns but this open to debate
* This is not extensible right now so I am too sure about this. We can read the statements from a configurable place so that at least the statements can be altered if needed by the developer. Let me know what you think.
* Should I move the calls
```
if (Logger.IsEnabled(LogLevel.Warning))
                {
                    Logger.LogWarning("Message with {userId}", await UserManager.GetUserIdAsync(user));
                }
```
to a private method 

```
await Logger.LogWarningAsync(""Message with {userId}", user);
```
This will check if logger is enabled and then log message extracting the userId. This does not look good to me since the method should be Async and then we need to await on it. I am not for this hence not included in the PR.
* I am logging signin errors in Warning, successful signin in Verbose and successful login + two factor needed in Information. Let me know if we should be reverting to using just to levels. In that case should it be Warning/Information or Warning/Verbose ?
