### PR TITLE
Updating stores to use TypeDescriptor for type conversion

### DIFF
--- a/src/Microsoft.AspNet.Identity.EntityFramework/RoleStore.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/RoleStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -160,7 +161,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
             {
                 return default(TKey);
             }
-            return (TKey)Convert.ChangeType(id, typeof(TKey));
+            return (TKey)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(id);
         }
 
         public virtual string ConvertIdToString(TKey id)

--- a/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
@@ -212,7 +213,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
             {
                 return default(TKey);
             }
-            return (TKey)Convert.ChangeType(id, typeof(TKey));
+            return (TKey)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(id);
         }
 
         public virtual string ConvertIdToString(TKey id)

--- a/src/Microsoft.AspNet.Identity.EntityFramework/project.json
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/project.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "System.Collections": "4.0.10-beta-*",
         "System.ComponentModel": "4.0.0-beta-*",
+        "System.ComponentModel.TypeConverter": "4.0.0-beta-*",
         "System.Diagnostics.Debug": "4.0.10-beta-*",
         "System.Diagnostics.Tools": "4.0.0-beta-*",
         "System.Globalization": "4.0.10-beta-*",

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
@@ -43,21 +43,11 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         public class ApplicationUserStore : UserStore<GuidUser, GuidRole, TestDbContext, Guid>
         {
             public ApplicationUserStore(TestDbContext context) : base(context) { }
-
-            public override Guid ConvertIdFromString(string userId)
-            {
-                return new Guid(userId);
-            }
         }
 
         public class ApplicationRoleStore : RoleStore<GuidRole, TestDbContext, Guid>
         {
             public ApplicationRoleStore(TestDbContext context) : base(context) { }
-
-            public override Guid ConvertIdFromString(string id)
-            {
-                return new Guid(id);
-            }
         }
 
         protected override void AddUserStore(IServiceCollection services, object context = null)


### PR DESCRIPTION
@HaoK @divega 

Fix for https://github.com/aspnet/Identity/issues/420 

The `TypeDescriptor` class is available in both desktop and core clr so taking this change. Verified it functionally. Removed the existing code in functional tests which was causing it pass incorrectly so now we have coverage there as well