### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Identity.EntityFramework/RoleStore.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/RoleStore.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
             Context = context;
             ErrorDescriber = describer ?? new IdentityErrorDescriber();

--- a/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
             Context = context;
             ErrorDescriber = describer ?? new IdentityErrorDescriber();

--- a/src/Microsoft.AspNet.Identity/BuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Identity/BuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (app == null)
             {
-                throw new ArgumentNullException("app");
+                throw new ArgumentNullException(nameof(app));
             }
             app.UseCookieAuthentication(null, IdentityOptions.ExternalCookieAuthenticationScheme);
             app.UseCookieAuthentication(null, IdentityOptions.TwoFactorRememberMeCookieAuthenticationScheme);

--- a/src/Microsoft.AspNet.Identity/DataProtectionTokenProvider.cs
+++ b/src/Microsoft.AspNet.Identity/DataProtectionTokenProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (user == null)
             {
-                throw new ArgumentNullException("user");
+                throw new ArgumentNullException(nameof(user));
             }
             var ms = new MemoryStream();
             var userId = await manager.GetUserIdAsync(user);

--- a/src/Microsoft.AspNet.Identity/PasswordValidator.cs
+++ b/src/Microsoft.AspNet.Identity/PasswordValidator.cs
@@ -32,11 +32,11 @@ namespace Microsoft.AspNet.Identity
         {
             if (password == null)
             {
-                throw new ArgumentNullException("password");
+                throw new ArgumentNullException(nameof(password));
             }
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             var errors = new List<IdentityError>();
             var options = manager.Options.Password;

--- a/src/Microsoft.AspNet.Identity/PhoneNumberTokenProvider.cs
+++ b/src/Microsoft.AspNet.Identity/PhoneNumberTokenProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             var phoneNumber = await manager.GetPhoneNumberAsync(user);
             return !string.IsNullOrWhiteSpace(phoneNumber) && await manager.IsPhoneNumberConfirmedAsync(user);

--- a/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
+++ b/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (securityToken == null)
             {
-                throw new ArgumentNullException("securityToken");
+                throw new ArgumentNullException(nameof(securityToken));
             }
 
             // Allow a variance of no greater than 90 seconds in either direction
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (securityToken == null)
             {
-                throw new ArgumentNullException("securityToken");
+                throw new ArgumentNullException(nameof(securityToken));
             }
 
             // Allow a variance of no greater than 90 seconds in either direction

--- a/src/Microsoft.AspNet.Identity/RoleManager.cs
+++ b/src/Microsoft.AspNet.Identity/RoleManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (store == null)
             {
-                throw new ArgumentNullException("store");
+                throw new ArgumentNullException(nameof(store));
             }
             Store = store;
             KeyNormalizer = keyNormalizer ?? new UpperInvariantLookupNormalizer();

--- a/src/Microsoft.AspNet.Identity/RoleValidator.cs
+++ b/src/Microsoft.AspNet.Identity/RoleValidator.cs
@@ -31,11 +31,11 @@ namespace Microsoft.AspNet.Identity
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             if (role == null)
             {
-                throw new ArgumentNullException("role");
+                throw new ArgumentNullException(nameof(role));
             }
             var errors = new List<IdentityError>();
             await ValidateRoleName(manager, role, errors);

--- a/src/Microsoft.AspNet.Identity/TotpSecurityStampBasedTokenProvider.cs
+++ b/src/Microsoft.AspNet.Identity/TotpSecurityStampBasedTokenProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             var token = await manager.CreateSecurityTokenAsync(user);
             var modifier = await GetUserModifierAsync(purpose, manager, user);
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Identity
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             int code;
             if (!int.TryParse(token, out code))

--- a/src/Microsoft.AspNet.Identity/UserClaimsPrincipalFactory.cs
+++ b/src/Microsoft.AspNet.Identity/UserClaimsPrincipalFactory.cs
@@ -32,11 +32,11 @@ namespace Microsoft.AspNet.Identity
         {
             if (userManager == null)
             {
-                throw new ArgumentNullException("userManager");
+                throw new ArgumentNullException(nameof(userManager));
             }
             if (roleManager == null)
             {
-                throw new ArgumentNullException("roleManager");
+                throw new ArgumentNullException(nameof(roleManager));
             }
             if (optionsAccessor == null || optionsAccessor.Options == null)
             {

--- a/src/Microsoft.AspNet.Identity/UserValidator.cs
+++ b/src/Microsoft.AspNet.Identity/UserValidator.cs
@@ -36,11 +36,11 @@ namespace Microsoft.AspNet.Identity
         {
             if (manager == null)
             {
-                throw new ArgumentNullException("manager");
+                throw new ArgumentNullException(nameof(manager));
             }
             if (user == null)
             {
-                throw new ArgumentNullException("user");
+                throw new ArgumentNullException(nameof(user));
             }
             var errors = new List<IdentityError>();
             await ValidateUserName(manager, user, errors);

--- a/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
+++ b/test/Microsoft.AspNet.Identity.InMemory.Test/InMemoryUserStore.cs
@@ -368,7 +368,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         {
             if (String.IsNullOrEmpty(roleName))
             {
-                throw new ArgumentNullException("role");
+                throw new ArgumentNullException(nameof(roleName));
             }
 
             return Task.FromResult<IList<TUser>>(Users.Where(u => (u.Roles.Where(x => x.RoleId == roleName).Count() > 0)).Select(x => x).ToList());
@@ -378,7 +378,7 @@ namespace Microsoft.AspNet.Identity.InMemory
         {
             if (claim == null)
             {
-                throw new ArgumentNullException("claim");
+                throw new ArgumentNullException(nameof(claim));
             }
 
             var query = from user in Users


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason