### PR TITLE
Remove internal SecurityToken class

### DIFF
--- a/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
+++ b/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
@@ -9,20 +9,20 @@ using System.Text;
 
 namespace Microsoft.AspNet.Identity
 {
-    internal sealed class SecurityToken
-    {
-        private readonly byte[] _data;
+    //internal sealed class SecurityToken
+    //{
+    //    private readonly byte[] _data;
 
-        public SecurityToken(byte[] data)
-        {
-            _data = (byte[])data.Clone();
-        }
+    //    public SecurityToken(byte[] data)
+    //    {
+    //        _data = (byte[])data.Clone();
+    //    }
 
-        internal byte[] GetDataNoClone()
-        {
-            return _data;
-        }
-    }
+    //    internal byte[] GetDataNoClone()
+    //    {
+    //        return _data;
+    //    }
+    //}
 
     internal static class Rfc6238AuthenticationService
     {
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Identity
             return (ulong)(delta.Ticks / _timestep.Ticks);
         }
 
-        public static int GenerateCode(SecurityToken securityToken, string modifier = null)
+        public static int GenerateCode(byte[] securityToken, string modifier = null)
         {
             if (securityToken == null)
             {
@@ -81,13 +81,13 @@ namespace Microsoft.AspNet.Identity
 
             // Allow a variance of no greater than 90 seconds in either direction
             var currentTimeStep = GetCurrentTimeStepNumber();
-            using (var hashAlgorithm = new HMACSHA1(securityToken.GetDataNoClone()))
+            using (var hashAlgorithm = new HMACSHA1(securityToken))
             {
                 return ComputeTotp(hashAlgorithm, currentTimeStep, modifier);
             }
         }
 
-        public static bool ValidateCode(SecurityToken securityToken, int code, string modifier = null)
+        public static bool ValidateCode(byte[] securityToken, int code, string modifier = null)
         {
             if (securityToken == null)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.Identity
 
             // Allow a variance of no greater than 90 seconds in either direction
             var currentTimeStep = GetCurrentTimeStepNumber();
-            using (var hashAlgorithm = new HMACSHA1(securityToken.GetDataNoClone()))
+            using (var hashAlgorithm = new HMACSHA1(securityToken))
             {
                 for (var i = -2; i <= 2; i++)
                 {

--- a/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
+++ b/src/Microsoft.AspNet.Identity/Rfc6238AuthenticationService.cs
@@ -9,21 +9,6 @@ using System.Text;
 
 namespace Microsoft.AspNet.Identity
 {
-    //internal sealed class SecurityToken
-    //{
-    //    private readonly byte[] _data;
-
-    //    public SecurityToken(byte[] data)
-    //    {
-    //        _data = (byte[])data.Clone();
-    //    }
-
-    //    internal byte[] GetDataNoClone()
-    //    {
-    //        return _data;
-    //    }
-    //}
-
     internal static class Rfc6238AuthenticationService
     {
         private static readonly DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -1505,9 +1505,8 @@ namespace Microsoft.AspNet.Identity
         }
 
         // Two factor APIS
-        internal async Task<SecurityToken> CreateSecurityTokenAsync(TUser user)
+        internal async Task<byte[]> CreateSecurityTokenAsync(TUser user)
         {
-            return new SecurityToken(Encoding.Unicode.GetBytes(await GetSecurityStampAsync(user)));
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -1507,6 +1507,7 @@ namespace Microsoft.AspNet.Identity
         // Two factor APIS
         internal async Task<byte[]> CreateSecurityTokenAsync(TUser user)
         {
+            return Encoding.Unicode.GetBytes(await GetSecurityStampAsync(user));
         }
 
         /// <summary>


### PR DESCRIPTION
Unneeded, it was just wrapping a byte[], directly use the byte[] array

cc @blowdart @divega 