### PR TITLE
Enable lock out by default

### DIFF
--- a/samples/IdentitySample.Mvc/Controllers/AccountController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/AccountController.cs
@@ -46,7 +46,7 @@ namespace IdentitySample.Controllers
             ViewBag.ReturnUrl = returnUrl;
             if (ModelState.IsValid)
             {
-                var result = await SignInManager.PasswordSignInAsync(model.UserName, model.Password, model.RememberMe, shouldLockout: false);
+                var result = await SignInManager.PasswordSignInAsync(model.UserName, model.Password, model.RememberMe, lockoutOnFailure: false);
                 if (result.Succeeded)
                 {
                     return RedirectToLocal(returnUrl);

--- a/src/Microsoft.AspNet.Identity/LockoutOptions.cs
+++ b/src/Microsoft.AspNet.Identity/LockoutOptions.cs
@@ -11,15 +11,15 @@ namespace Microsoft.AspNet.Identity
     public class LockoutOptions
     {
         /// <summary>
-        /// Gets or sets a flag indicating whether users are locked out upon creation.
+        /// Gets or sets a flag indicating whether users can be locked out after creation.
         /// </summary>
         /// <value>
-        /// True if a newly created user is locked out, otherwise false.
+        /// True if a newly created user can be locked out, otherwise false.
         /// </value>
         /// <remarks>
-        /// Defaults to false.
+        /// Defaults to true.
         /// </remarks>
-        public bool EnabledByDefault { get; set; } = false;
+        public bool AllowedForNewUsers { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the number of failed access attempts allowed before a user is locked out,

--- a/src/Microsoft.AspNet.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNet.Identity/SignInManager.cs
@@ -186,11 +186,10 @@ namespace Microsoft.AspNet.Identity
         /// <param name="user">The user to sign in.</param>
         /// <param name="password">The password to attempt to sign in with.</param>
         /// <param name="isPersistent">Flag indicating whether the sign-in cookie should persist after the browser is closed.</param>
-        /// <param name="shouldLockout">Flag indicating if the user account should be locked if the sign in fails.</param>
+        /// <param name="lockoutOnFailure">Flag indicating if the user account should be locked if the sign in fails too many times.</param>
         /// <returns>The task object representing the asynchronous operation containing the <see name="SignInResult"/>
         /// for the sign-in attempt.</returns>
-        public virtual async Task<SignInResult> PasswordSignInAsync(TUser user, string password,
-            bool isPersistent, bool shouldLockout)
+        public virtual async Task<SignInResult> PasswordSignInAsync(TUser user, string password, bool isPersistent, bool lockoutOnFailure)
         {
             if (user == null)
             {
@@ -213,7 +212,7 @@ namespace Microsoft.AspNet.Identity
             }
             Logger.LogWarning("User {userId} failed to provide the correct password.", await UserManager.GetUserIdAsync(user));
 
-            if (UserManager.SupportsUserLockout && shouldLockout)
+            if (UserManager.SupportsUserLockout && lockoutOnFailure)
             {
                 // If lockout is requested, increment access failed count which might lock out the user
                 await UserManager.AccessFailedAsync(user);
@@ -232,11 +231,11 @@ namespace Microsoft.AspNet.Identity
         /// <param name="userName">The user name to sign in.</param>
         /// <param name="password">The password to attempt to sign in with.</param>
         /// <param name="isPersistent">Flag indicating whether the sign-in cookie should persist after the browser is closed.</param>
-        /// <param name="shouldLockout">Flag indicating if the user account should be locked if the sign in fails.</param>
+        /// <param name="lockoutOnFailure">Flag indicating if the user account should be locked if the sign in fails too many times.</param>
         /// <returns>The task object representing the asynchronous operation containing the <see name="SignInResult"/>
         /// for the sign-in attempt.</returns>
         public virtual async Task<SignInResult> PasswordSignInAsync(string userName, string password,
-            bool isPersistent, bool shouldLockout)
+            bool isPersistent, bool lockoutOnFailure)
         {
             var user = await UserManager.FindByNameAsync(userName);
             if (user == null)
@@ -244,7 +243,7 @@ namespace Microsoft.AspNet.Identity
                 return SignInResult.Failed;
             }
 
-            return await PasswordSignInAsync(user, password, isPersistent, shouldLockout);
+            return await PasswordSignInAsync(user, password, isPersistent, lockoutOnFailure);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AspNet.Identity
             {
                 return result;
             }
-            if (Options.Lockout.EnabledByDefault && SupportsUserLockout)
+            if (Options.Lockout.AllowedForNewUsers && SupportsUserLockout)
             {
                 await GetUserLockoutStore().SetLockoutEnabledAsync(user, true, CancellationToken);
             }

--- a/test/Microsoft.AspNet.Identity.Test/IdentityOptionsTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/IdentityOptionsTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Identity.Test
         public void VerifyDefaultOptions()
         {
             var options = new IdentityOptions();
-            Assert.False(options.Lockout.EnabledByDefault);
+            Assert.True(options.Lockout.AllowedForNewUsers);
             Assert.Equal(TimeSpan.FromMinutes(5), options.Lockout.DefaultLockoutTimeSpan);
             Assert.Equal(5, options.Lockout.MaxFailedAccessAttempts);
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Identity.Test
                 {"identity:password:RequireUpperCase", "false"},
                 {"identity:password:RequireDigit", "false"},
                 {"identity:password:RequireLowerCase", "false"},
-                {"identity:lockout:EnabledByDefault", "TRUe"},
+                {"identity:lockout:AllowedForNewUsers", "FALSe"},
                 {"identity:lockout:MaxFailedAccessAttempts", "1000"}
             };
             var builder = new ConfigurationBuilder(new MemoryConfigurationSource(dic));
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(options.Password.RequireNonLetterOrDigit);
             Assert.False(options.Password.RequireUppercase);
             Assert.Equal(10, options.Password.RequiredLength);
-            Assert.True(options.Lockout.EnabledByDefault);
+            Assert.False(options.Lockout.AllowedForNewUsers);
             Assert.Equal(1000, options.Lockout.MaxFailedAccessAttempts);
         }
 

--- a/test/Shared/MockHelpers.cs
+++ b/test/Shared/MockHelpers.cs
@@ -69,6 +69,7 @@ namespace Microsoft.AspNet.Identity.Test
             store = store ?? new Mock<IUserStore<TUser>>().Object;
             var options = new Mock<IOptions<IdentityOptions>>();
             var idOptions = new IdentityOptions();
+            idOptions.Lockout.AllowedForNewUsers = false;
             options.Setup(o => o.Options).Returns(idOptions);
             var userValidators = new List<IUserValidator<TUser>>();
             var validator = new Mock<IUserValidator<TUser>>();

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -814,7 +814,6 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromHours(1);
-            mgr.Options.Lockout.EnabledByDefault = true;
             mgr.Options.Lockout.MaxFailedAccessAttempts = 0;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
@@ -833,7 +832,6 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromHours(1);
-            mgr.Options.Lockout.EnabledByDefault = true;
             mgr.Options.Lockout.MaxFailedAccessAttempts = 2;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
@@ -855,7 +853,6 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromHours(1);
-            mgr.Options.Lockout.EnabledByDefault = true;
             mgr.Options.Lockout.MaxFailedAccessAttempts = 2;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
@@ -880,6 +877,7 @@ namespace Microsoft.AspNet.Identity.Test
         {
             var mgr = CreateManager();
             mgr.Options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromHours(1);
+            mgr.Options.Lockout.AllowedForNewUsers = false;
             mgr.Options.Lockout.MaxFailedAccessAttempts = 2;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
@@ -902,7 +900,6 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task UserNotLockedOutWithNullDateTimeAndIsSetToNullDate()
         {
             var mgr = CreateManager();
-            mgr.Options.Lockout.EnabledByDefault = true;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
@@ -915,6 +912,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task LockoutFailsIfNotEnabled()
         {
             var mgr = CreateManager();
+            mgr.Options.Lockout.AllowedForNewUsers = false;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.False(await mgr.GetLockoutEnabledAsync(user));
@@ -928,7 +926,6 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task LockoutEndToUtcNowMinus1SecInUserShouldNotBeLockedOut()
         {
             var mgr = CreateManager();
-            mgr.Options.Lockout.EnabledByDefault = true;
             var user = CreateTestUser(lockoutEnd: DateTimeOffset.UtcNow.AddSeconds(-1));
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
@@ -939,7 +936,6 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task LockoutEndToUtcNowSubOneSecondWithManagerShouldNotBeLockedOut()
         {
             var mgr = CreateManager();
-            mgr.Options.Lockout.EnabledByDefault = true;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));
@@ -951,7 +947,6 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task LockoutEndToUtcNowPlus5ShouldBeLockedOut()
         {
             var mgr = CreateManager();
-            mgr.Options.Lockout.EnabledByDefault = true;
             var lockoutEnd = DateTimeOffset.UtcNow.AddMinutes(5);
             var user = CreateTestUser(lockoutEnd: lockoutEnd);
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
@@ -963,7 +958,6 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task UserLockedOutWithDateTimeLocalKindNowPlus30()
         {
             var mgr = CreateManager();
-            mgr.Options.Lockout.EnabledByDefault = true;
             var user = CreateTestUser();
             IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
             Assert.True(await mgr.GetLockoutEnabledAsync(user));


### PR DESCRIPTION
Fixes https://github.com/aspnet/Identity/issues/478

Note this is a breaking change for templates as the AccountController was using this parameter by name

cc @divega @rustd 