### PR TITLE
Remove useless and incompatible dependencies

### DIFF
--- a/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.InMemory.Test/project.json
@@ -8,7 +8,6 @@
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "EntityFramework.InMemory": "7.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
-    "System.Security.Claims": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "compile": "..\\Shared\\*.cs",

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/project.json
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/project.json
@@ -10,7 +10,6 @@
     "Microsoft.AspNet.TestHost": "1.0.0-*",
     "Microsoft.AspNet.Testing": "1.0.0-*",
     "Microsoft.Framework.OptionsModel" : "1.0.0-*",
-    "System.Security.Claims": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
   "compile": "..\\Shared\\*.cs",


### PR DESCRIPTION
Fixing CI build. `System.Security.Claims` is incompatible with dnx451, which is the framework used by tests.

@anpete 