### PR TITLE
Fixed UserValidator failing when UserName contains a hyphen

### DIFF
--- a/src/Microsoft.AspNet.Identity/UserOptions.cs
+++ b/src/Microsoft.AspNet.Identity/UserOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Identity
         /// validation via regular expressions will timeout and fail after the value set in the <see cref="UserNameValidationRegexTimeout"/>
         /// property.
         /// </remarks>
-        public string UserNameValidationRegex { get; set; } = "^[a-zA-Z0-9@_\\.]+$";
+        public string UserNameValidationRegex { get; set; } = "^[a-zA-Z0-9@_\\.-]+$";
 
         /// <summary>
         /// Gets or sets the timeout value used after which user name validation via the <see cref="UserNameValidationRegex"/> will fail if it has

--- a/test/Microsoft.AspNet.Identity.Test/UserValidatorTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/UserValidatorTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         [Theory]
+        [InlineData("test_email@foo-bar.com", true)]
         [InlineData("test_email@foo.com", true)]
         [InlineData("hao", true)]
         [InlineData("test123", true)]
@@ -67,6 +68,7 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         [Theory]
+        [InlineData("test_email@foo-bar.com", true)]
         [InlineData("test_email@foo.com", true)]
         [InlineData("hao", true)]
         [InlineData("test123", true)]


### PR DESCRIPTION
UserValidator would fail to validate usernames containing an email address with a hyphen in either the address or domain part