### PR TITLE
Reenable tests/cascading deletes

### DIFF
--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -20,22 +20,22 @@ namespace Microsoft.AspNet.Identity.EntityFramework
     {
         public IdentityDbContext(DbContextOptions options) : base(options)
         {
-            
+
         }
 
         public IdentityDbContext(IServiceProvider serviceProvider) : base(serviceProvider)
         {
-            
+
         }
 
         public IdentityDbContext(IServiceProvider serviceProvider, DbContextOptions options) : base(serviceProvider, options)
         {
-            
+
         }
 
         protected IdentityDbContext()
         {
-            
+
         }
 
         public DbSet<TUser> Users { get; set; }
@@ -48,62 +48,59 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         protected override void OnModelCreating(ModelBuilder builder)
         {
             builder.Entity<TUser>(b =>
-                {
-                    b.HasKey(u => u.Id);
-                    b.HasIndex(u => u.NormalizedUserName).HasName("UserNameIndex");
-                    b.HasIndex(u => u.NormalizedEmail).HasName("EmailIndex");
-                    b.ToTable("AspNetUsers");
-                    b.Property(u => u.ConcurrencyStamp).IsConcurrencyToken();
+            {
+                b.HasKey(u => u.Id);
+                b.HasIndex(u => u.NormalizedUserName).HasName("UserNameIndex");
+                b.HasIndex(u => u.NormalizedEmail).HasName("EmailIndex");
+                b.ToTable("AspNetUsers");
+                b.Property(u => u.ConcurrencyStamp).IsConcurrencyToken();
 
-                    b.Property(u => u.UserName).HasMaxLength(256);
-                    b.Property(u => u.NormalizedUserName).HasMaxLength(256);
-                    b.Property(u => u.Email).HasMaxLength(256);
-                    b.Property(u => u.NormalizedEmail).HasMaxLength(256);
-                    b.HasMany(u => u.Claims).WithOne().HasForeignKey(uc => uc.UserId);
-                    b.HasMany(u => u.Logins).WithOne().HasForeignKey(ul => ul.UserId);
-                    b.HasMany(u => u.Roles).WithOne().HasForeignKey(ur => ur.UserId);
-                });
+                b.Property(u => u.UserName).HasMaxLength(256);
+                b.Property(u => u.NormalizedUserName).HasMaxLength(256);
+                b.Property(u => u.Email).HasMaxLength(256);
+                b.Property(u => u.NormalizedEmail).HasMaxLength(256);
+                b.HasMany(u => u.Claims).WithOne().HasForeignKey(uc => uc.UserId).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(u => u.Logins).WithOne().HasForeignKey(ul => ul.UserId).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(u => u.Roles).WithOne().HasForeignKey(ur => ur.UserId).OnDelete(DeleteBehavior.Cascade);
+            });
 
             builder.Entity<TRole>(b =>
-                {
-                    b.HasKey(r => r.Id);
-                    b.HasIndex(r => r.NormalizedName).HasName("RoleNameIndex");
-                    b.ToTable("AspNetRoles");
-                    b.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
+            {
+                b.HasKey(r => r.Id);
+                b.HasIndex(r => r.NormalizedName).HasName("RoleNameIndex");
+                b.ToTable("AspNetRoles");
+                b.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
 
-                    b.Property(u => u.Name).HasMaxLength(256);
-                    b.Property(u => u.NormalizedName).HasMaxLength(256);
+                b.Property(u => u.Name).HasMaxLength(256);
+                b.Property(u => u.NormalizedName).HasMaxLength(256);
 
-                    b.HasMany(r => r.Users).WithOne().HasForeignKey(ur => ur.RoleId);
-                    b.HasMany(r => r.Claims).WithOne().HasForeignKey(rc => rc.RoleId);
-                });
+                b.HasMany(r => r.Users).WithOne().HasForeignKey(ur => ur.RoleId).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(r => r.Claims).WithOne().HasForeignKey(rc => rc.RoleId).OnDelete(DeleteBehavior.Cascade);
+            });
 
             builder.Entity<IdentityUserClaim<TKey>>(b =>
-                {
-                    b.HasKey(uc => uc.Id);
-                    b.ToTable("AspNetUserClaims");
-                });
+            {
+                b.HasKey(uc => uc.Id);
+                b.ToTable("AspNetUserClaims");
+            });
 
             builder.Entity<IdentityRoleClaim<TKey>>(b =>
-                {
-                    b.HasKey(rc => rc.Id);
-                    b.ToTable("AspNetRoleClaims");
-                });
+            {
+                b.HasKey(rc => rc.Id);
+                b.ToTable("AspNetRoleClaims");
+            });
 
             builder.Entity<IdentityUserRole<TKey>>(b =>
-                {
-                    b.HasKey(r => new { r.UserId, r.RoleId });
-                    b.ToTable("AspNetUserRoles");
-                });
-            // Blocks delete currently without cascade
-            //.ForeignKeys(fk => fk.ForeignKey<TUser>(f => f.UserId))
-            //.ForeignKeys(fk => fk.ForeignKey<TRole>(f => f.RoleId));
+            {
+                b.HasKey(r => new { r.UserId, r.RoleId });
+                b.ToTable("AspNetUserRoles");
+            });
 
             builder.Entity<IdentityUserLogin<TKey>>(b =>
-                {
-                    b.HasKey(l => new { l.LoginProvider, l.ProviderKey });
-                    b.ToTable("AspNetUserLogins");
-                });
+            {
+                b.HasKey(l => new { l.LoginProvider, l.ProviderKey });
+                b.ToTable("AspNetUserLogins");
+            });
         }
     }
 }

--- a/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/IdentityDbContext.cs
@@ -59,9 +59,9 @@ namespace Microsoft.AspNet.Identity.EntityFramework
                 b.Property(u => u.NormalizedUserName).HasMaxLength(256);
                 b.Property(u => u.Email).HasMaxLength(256);
                 b.Property(u => u.NormalizedEmail).HasMaxLength(256);
-                b.HasMany(u => u.Claims).WithOne().HasForeignKey(uc => uc.UserId).OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(u => u.Logins).WithOne().HasForeignKey(ul => ul.UserId).OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(u => u.Roles).WithOne().HasForeignKey(ur => ur.UserId).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(u => u.Claims).WithOne().HasForeignKey(uc => uc.UserId).IsRequired();
+                b.HasMany(u => u.Logins).WithOne().HasForeignKey(ul => ul.UserId).IsRequired();
+                b.HasMany(u => u.Roles).WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
             });
 
             builder.Entity<TRole>(b =>
@@ -74,8 +74,8 @@ namespace Microsoft.AspNet.Identity.EntityFramework
                 b.Property(u => u.Name).HasMaxLength(256);
                 b.Property(u => u.NormalizedName).HasMaxLength(256);
 
-                b.HasMany(r => r.Users).WithOne().HasForeignKey(ur => ur.RoleId).OnDelete(DeleteBehavior.Cascade);
-                b.HasMany(r => r.Claims).WithOne().HasForeignKey(rc => rc.RoleId).OnDelete(DeleteBehavior.Cascade);
+                b.HasMany(r => r.Users).WithOne().HasForeignKey(ur => ur.RoleId).IsRequired();
+                b.HasMany(r => r.Claims).WithOne().HasForeignKey(rc => rc.RoleId).IsRequired();
             });
 
             builder.Entity<IdentityUserClaim<TKey>>(b =>

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/CustomPocoTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/CustomPocoTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(-1000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseStart()
         {
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(10000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseDone()
         {
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             db.Database.EnsureDeleted();
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateNameGuid()
         {
@@ -84,7 +84,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateNameString()
         {
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserInt()
         {
@@ -118,7 +118,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserIntViaSet()
         {
@@ -135,7 +135,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateNameInt()
         {
@@ -153,7 +153,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateNameIntWithSet()
         {

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/DefaultPocoTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/DefaultPocoTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(-1000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseStart()
         {
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             return builder;
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task EnsureStartupUsageWorks()
         {
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             IdentityResultAssert.IsSuccess(await userManager.DeleteAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanIncludeUserClaimsTest()
         {
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.Equal(10, user.Claims.Count());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanIncludeUserLoginsTest()
         {
@@ -135,7 +135,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.Equal(10, user.Logins.Count());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanIncludeUserRolesTest()
         {
@@ -177,7 +177,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanIncludeRoleClaimsTest()
         {
@@ -206,7 +206,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(10000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseDone()
         {

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/SqlStoreTestBase.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/SqlStoreTestBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
 
 
         [TestPriority(-1000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseStart()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(10000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseDone()
         {
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             CreateContext();
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void EnsureDefaultSchema()
         {
@@ -180,7 +180,58 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        public async Task DeleteRoleNonEmptySucceedsTest()
+        {
+            // Need fail if not empty?
+            var context = CreateTestContext();
+            var userMgr = CreateManager(context);
+            var roleMgr = CreateRoleManager(context);
+            var roleName = "delete" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.False(await roleMgr.RoleExistsAsync(roleName));
+            IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
+            var user = CreateTestUser();
+            IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
+            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
+            var roles = await userMgr.GetRolesAsync(user);
+            Assert.Equal(1, roles.Count());
+            IdentityResultAssert.IsSuccess(await roleMgr.DeleteAsync(role));
+            Assert.Null(await roleMgr.FindByNameAsync(roleName));
+            Assert.False(await roleMgr.RoleExistsAsync(roleName));
+            // REVIEW: We should throw if deleteing a non empty role?
+            roles = await userMgr.GetRolesAsync(user);
+
+            Assert.Equal(0, roles.Count());
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        public async Task DeleteUserRemovesFromRoleTest()
+        {
+            // Need fail if not empty?
+            var userMgr = CreateManager();
+            var roleMgr = CreateRoleManager();
+            var roleName = "deleteUserRemove" + Guid.NewGuid().ToString();
+            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
+            Assert.False(await roleMgr.RoleExistsAsync(roleName));
+            IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
+            var user = CreateTestUser();
+            IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
+            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
+
+            var roles = await userMgr.GetRolesAsync(user);
+            Assert.Equal(1, roles.Count());
+
+            IdentityResultAssert.IsSuccess(await userMgr.DeleteAsync(user));
+
+            roles = await userMgr.GetRolesAsync(user);
+            Assert.Equal(0, roles.Count());
+        }
+
+
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void CanCreateUserUsingEF()
         {
@@ -194,7 +245,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUsingManager()
         {
@@ -228,7 +279,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LoadFromDbFindByIdTest()
         {
@@ -245,7 +296,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.Equal(2, (await manager.GetRolesAsync(userById)).Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LoadFromDbFindByNameTest()
         {
@@ -261,7 +312,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.Equal(2, (await manager.GetRolesAsync(userByName)).Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LoadFromDbFindByLoginTest()
         {
@@ -277,7 +328,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.Equal(2, (await manager.GetRolesAsync(userByLogin)).Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LoadFromDbFindByEmailTest()
         {

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         private readonly string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=SqlUserStoreTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;";
 
         [TestPriority(-1000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseStart()
         {
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [TestPriority(10000)]
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void DropDatabaseDone()
         {
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             db.Database.EnsureDeleted();
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void CanCreateUserUsingEF()
         {
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             services.AddInstance<IRoleStore<IdentityRole>>(new RoleStore<IdentityRole, IdentityDbContext>((IdentityDbContext)context));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         public async Task SqlUserStoreMethodsThrowWhenDisposedTest()
         {
             var store = new UserStore(new IdentityDbContext());
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
                 async () => await store.GetPhoneNumberConfirmedAsync(null));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         public async Task UserStorePublicNullCheckTest()
         {
             Assert.Throws<ArgumentNullException>("context", () => new UserStore(null));
@@ -192,7 +192,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             await Assert.ThrowsAsync<ArgumentException>("roleName", async () => await store.IsInRoleAsync(new IdentityUser("fake"), ""));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUsingManager()
         {
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             IdentityResultAssert.IsSuccess(await manager.DeleteAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task TwoUsersSamePasswordDifferentHash()
         {
@@ -216,7 +216,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             Assert.NotEqual(userA.PasswordHash, userB.PasswordHash);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddUserToUnknownRoleFails()
         {
@@ -227,7 +227,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
                 async () => await manager.AddToRoleAsync(u, "bogus"));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConcurrentUpdatesWillFail()
         {
@@ -254,7 +254,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConcurrentUpdatesWillFailWithDetachedUser()
         {
@@ -279,7 +279,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task DeleteAModifiedUserWillFail()
         {
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConcurrentRoleUpdatesWillFail()
         {
@@ -332,7 +332,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConcurrentRoleUpdatesWillFailWithDetachedRole()
         {
@@ -358,7 +358,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task DeleteAModifiedRoleWillFail()
         {

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Identity.Test
         protected abstract Expression<Func<TRole, bool>> RoleNameEqualsPredicate(string roleName);
         protected abstract Expression<Func<TRole, bool>> RoleNameStartsWithPredicate(string roleName);
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanDeleteUser()
         {
@@ -110,7 +110,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Null(await manager.FindByIdAsync(userId));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateUserName()
         {
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Null(await manager.FindByNameAsync(name));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CheckSetUserNameValidatesUser()
         {
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(newUser)} validation failed: {error.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task SetUserNameUpdatesSecurityStamp()
         {
@@ -166,7 +166,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CheckSetEmailValidatesUser()
         {
@@ -186,7 +186,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsFailure(await manager.SetEmailAsync(newUser, ""), _errorDescriber.InvalidEmail(""));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdatePasswordUsingHasher()
         {
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await manager.CheckPasswordAsync(user, "New"));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanFindById()
         {
@@ -213,7 +213,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotNull(await manager.FindByIdAsync(await manager.GetUserIdAsync(user)));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task UserValidatorCanBlockCreate()
         {
@@ -225,7 +225,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task UserValidatorCanBlockUpdate()
         {
@@ -238,7 +238,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChainUserValidators()
         {
@@ -279,7 +279,7 @@ namespace Microsoft.AspNet.Identity.Test
         }
 #endif
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task PasswordValidatorCanBlockAddPassword()
         {
@@ -293,7 +293,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChainPasswordValidators()
         {
@@ -308,7 +308,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(2, result.Errors.Count());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task PasswordValidatorCanBlockChangePassword()
         {
@@ -322,7 +322,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task PasswordValidatorCanBlockCreateUser()
         {
@@ -334,7 +334,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} password validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserNoPassword()
         {
@@ -350,7 +350,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, logins.Count());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserAddLogin()
         {
@@ -369,7 +369,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(display, logins.First().ProviderDisplayName);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserLoginAndAddPassword()
         {
@@ -389,7 +389,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await manager.CheckPasswordAsync(user, "password"));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddPasswordFailsIfAlreadyHave()
         {
@@ -402,7 +402,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User {await manager.GetUserIdAsync(user)} already has a password.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateUserAddRemoveLogin()
         {
@@ -430,7 +430,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanRemovePassword()
         {
@@ -447,7 +447,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChangePassword()
         {
@@ -464,7 +464,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanAddRemoveUserClaim()
         {
@@ -490,7 +490,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, userClaims.Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task RemoveClaimOnlyAffectsUser()
         {
@@ -520,7 +520,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(3, userClaims2.Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanReplaceUserClaim()
         {
@@ -540,7 +540,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(claim.Value, newClaim.Value);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ReplaceUserClaimOnlyAffectsUser()
         {
@@ -570,7 +570,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal("a", oldClaim2.Value);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ChangePasswordFallsIfPasswordWrong()
         {
@@ -582,7 +582,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Change password failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddDupeUserNameFails()
         {
@@ -594,7 +594,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), _errorDescriber.DuplicateUserName(username));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddDupeEmailAllowedByDefault()
         {
@@ -606,7 +606,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user2, await manager.GetEmailAsync(user)));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddDupeEmailFailsWhenUniqueEmailRequired()
         {
@@ -618,7 +618,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsFailure(await manager.CreateAsync(user2), _errorDescriber.DuplicateEmail("FooUser@yup.com"));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task UpdateSecurityStampActuallyChanges()
         {
@@ -632,7 +632,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddDupeLoginFails()
         {
@@ -647,7 +647,7 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         // Email tests
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanFindByEmail()
         {
@@ -659,7 +659,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(user, fetch);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanFindUsersViaUserQuerable()
         {
@@ -676,7 +676,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConfirmEmailFalseByDefaultTest()
         {
@@ -714,7 +714,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanResetPasswordWithStaticTokenProvider()
         {
@@ -736,7 +736,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task PasswordValidatorCanBlockResetPasswordWithStaticTokenProvider()
         {
@@ -759,7 +759,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ResetPasswordWithStaticTokenProviderFailsWithWrongToken()
         {
@@ -778,7 +778,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanGenerateAndVerifyUserTokenWithStaticTokenProvider()
         {
@@ -803,7 +803,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: test for user { await manager.GetUserIdAsync(user2)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanConfirmEmailWithStaticToken()
         {
@@ -822,7 +822,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await manager.IsEmailConfirmedAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConfirmEmailWithStaticTokenFailsWithWrongToken()
         {
@@ -837,7 +837,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyUserTokenAsync() failed with purpose: EmailConfirmation for user { await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ConfirmTokenFailsAfterPasswordChange()
         {
@@ -855,7 +855,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         // Lockout tests
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task SingleFailureLockout()
         {
@@ -874,7 +874,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task TwoFailureLockout()
         {
@@ -896,7 +896,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ResetAccessCountPreventsLockout()
         {
@@ -921,7 +921,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(1, await mgr.GetAccessFailedCountAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanEnableLockoutManuallyAndLockout()
         {
@@ -946,7 +946,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task UserNotLockedOutWithNullDateTimeAndIsSetToNullDate()
         {
@@ -959,7 +959,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(new DateTimeOffset(), await mgr.GetLockoutEndDateAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LockoutFailsIfNotEnabled()
         {
@@ -974,7 +974,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LockoutEndToUtcNowMinus1SecInUserShouldNotBeLockedOut()
         {
@@ -985,7 +985,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LockoutEndToUtcNowSubOneSecondWithManagerShouldNotBeLockedOut()
         {
@@ -997,7 +997,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await mgr.IsLockedOutAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task LockoutEndToUtcNowPlus5ShouldBeLockedOut()
         {
@@ -1009,7 +1009,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await mgr.IsLockedOutAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task UserLockedOutWithDateTimeLocalKindNowPlus30()
         {
@@ -1025,7 +1025,7 @@ namespace Microsoft.AspNet.Identity.Test
         }
 
         // Role Tests
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanCreateRoleTest()
         {
@@ -1058,7 +1058,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task BadValidatorBlocksCreateRole()
         {
@@ -1071,7 +1071,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Role {await manager.GetRoleIdAsync(role)} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChainRoleValidators()
         {
@@ -1086,7 +1086,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(2, result.Errors.Count());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task BadValidatorBlocksRoleUpdate()
         {
@@ -1100,7 +1100,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"Role {await manager.GetRoleIdAsync(role)} validation failed: {AlwaysBadValidator.ErrorMessage.Code}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanDeleteRole()
         {
@@ -1114,7 +1114,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await manager.RoleExistsAsync(roleName));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanAddRemoveRoleClaim()
         {
@@ -1150,7 +1150,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(3, safeRoleClaims.Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanRoleFindById()
         {
@@ -1161,7 +1161,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(role, await manager.FindByIdAsync(await manager.GetRoleIdAsync(role)));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanRoleFindByName()
         {
@@ -1174,7 +1174,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(role, await manager.FindByNameAsync(roleName));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanUpdateRoleName()
         {
@@ -1190,7 +1190,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(role, await manager.FindByNameAsync("Changed"));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanQueryableRoles()
         {
@@ -1207,53 +1207,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        // Enable when delete on cascade is supported in EF
-        // [ConditionalTheory]
-        //[FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        public async Task DeleteRoleNonEmptySucceedsTest()
-        {
-            // Need fail if not empty?
-            var context = CreateTestContext();
-            var userMgr = CreateManager(context);
-            var roleMgr = CreateRoleManager(context);
-            var roleName = "delete" + Guid.NewGuid().ToString();
-            var role = CreateTestRole(roleName, useRoleNamePrefixAsRoleName: true);
-            Assert.False(await roleMgr.RoleExistsAsync(roleName));
-            IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-            var user = CreateTestUser();
-            IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
-            IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
-            var roles = await userMgr.GetRolesAsync(user);
-            Assert.Equal(1, roles.Count());
-            IdentityResultAssert.IsSuccess(await roleMgr.DeleteAsync(role));
-            Assert.Null(await roleMgr.FindByNameAsync(roleName));
-            Assert.False(await roleMgr.RoleExistsAsync(roleName));
-            // REVIEW: We should throw if deleteing a non empty role?
-            roles = await userMgr.GetRolesAsync(user);
-
-            // REVIEW: This depends on cascading deletes
-            Assert.Equal(0, roles.Count());
-        }
-
-        // TODO: cascading deletes?  navigation properties not working
-        ////[ConditionalTheory]
-        //[FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        ////public async Task DeleteUserRemovesFromRoleTest()
-        ////{
-        ////    // Need fail if not empty?
-        ////    var userMgr = CreateManager();
-        ////    var roleMgr = CreateRoleManager();
-        ////    var role = CreateRole("deleteNonEmpty");
-        ////    Assert.False(await roleMgr.RoleExistsAsync(roleName));
-        ////    IdentityResultAssert.IsSuccess(await roleMgr.CreateAsync(role));
-        ////    var user = new TUser() { UserName = "t");
-        ////    IdentityResultAssert.IsSuccess(await userMgr.CreateAsync(user));
-        ////    IdentityResultAssert.IsSuccess(await userMgr.AddToRoleAsync(user, roleName));
-        ////    IdentityResultAssert.IsSuccess(await userMgr.DeleteAsync(user));
-        ////    role = roleMgr.FindByIdAsync(role.Id);
-        ////}
-
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CreateRoleFailsIfExists()
         {
@@ -1267,7 +1221,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.IsFailure(await manager.CreateAsync(role2));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanAddUsersToRole()
         {
@@ -1289,7 +1243,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanGetRolesForUser()
         {
@@ -1324,7 +1278,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task RemoveUserFromRoleWithMultipleRoles()
         {
@@ -1344,7 +1298,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.False(await userManager.IsInRoleAsync(user, await roleManager.GetRoleNameAsync(roles[2])));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanRemoveUsersFromRole()
         {
@@ -1370,7 +1324,7 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task RemoveUserNotInRoleFails()
         {
@@ -1387,7 +1341,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User {await userMgr.GetUserIdAsync(user)} is not in role {roleName}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddUserToRoleFailsIfAlreadyInRole()
         {
@@ -1405,7 +1359,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(userMgr.Logger, $"User {await userMgr.GetUserIdAsync(user)} is already in role {roleName}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task AddUserToRolesIgnoresDuplicates()
         {
@@ -1422,7 +1376,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await userMgr.IsInRoleAsync(user, roleName));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanFindRoleByNameWithManager()
         {
@@ -1433,7 +1387,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotNull(await roleMgr.FindByNameAsync(roleName));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanFindRoleWithManager()
         {
@@ -1444,7 +1398,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(roleName, await roleMgr.GetRoleNameAsync(await roleMgr.FindByNameAsync(roleName)));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task SetPhoneNumberTest()
         {
@@ -1458,7 +1412,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChangePhoneNumber()
         {
@@ -1474,7 +1428,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ChangePhoneNumberFailsWithWrongToken()
         {
@@ -1491,7 +1445,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ChangePhoneNumberFailsWithWrongPhoneNumber()
         {
@@ -1508,7 +1462,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanVerifyPhoneNumber()
         {
@@ -1529,7 +1483,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyChangePhoneNumberTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChangeEmail()
         {
@@ -1548,7 +1502,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanChangeEmailWithDifferentTokenProvider()
         {
@@ -1570,7 +1524,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.NotEqual(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ChangeEmailFailsWithWrongToken()
         {
@@ -1590,7 +1544,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ChangeEmailFailsWithEmail()
         {
@@ -1611,7 +1565,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(stamp, await manager.GetSecurityStampAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task EmailFactorFailsAfterSecurityStampChangeTest()
         {
@@ -1633,7 +1587,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task EnableTwoFactorChangesSecurityStamp()
         {
@@ -1647,7 +1601,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(await manager.GetTwoFactorEnabledAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task GenerateTwoFactorWithUnknownFactorProviderWillThrow()
         {
@@ -1662,7 +1616,7 @@ namespace Microsoft.AspNet.Identity.Test
                 () => manager.VerifyTwoFactorTokenAsync(user, "bogus", "bogus"), error);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task GetValidTwoFactorTestEmptyWithNoProviders()
         {
@@ -1674,7 +1628,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.True(!factors.Any());
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanGetValidTwoFactor()
         {
@@ -1706,7 +1660,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal("Phone", factors[0]);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task PhoneFactorFailsAfterSecurityStampChangeTest()
         {
@@ -1723,7 +1677,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task VerifyTokenFromWrongTokenProviderFails()
         {
@@ -1736,7 +1690,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task VerifyWithWrongSmsTokenFails()
         {
@@ -1747,7 +1701,7 @@ namespace Microsoft.AspNet.Identity.Test
             IdentityResultAssert.VerifyLogMessage(manager.Logger, $"VerifyTwoFactorTokenAsync() failed for user {await manager.GetUserIdAsync(user)}.");
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task NullableDateTimeOperationTest()
         {
@@ -1766,7 +1720,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(DateTimeOffset.Parse("01/01/2014"), await userMgr.GetLockoutEndDateAsync(user));
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanGetUsersWithClaims()
         {
@@ -1788,7 +1742,7 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, (await manager.GetUsersForClaimAsync(new Claim("123", "456"))).Count);
         }
 
-        [ConditionalTheory]
+        [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task CanGetUsersInRole()
         {


### PR DESCRIPTION
cc @divega 

Looks like we were a bit agressive in disabling tests to fix travis before :)  Turns out ConditionalTheory with no InlineData no-ops the tests...  I noticed this only because the new cascading tests weren't failing doh!