### PR TITLE
Make HttpContextAccessor Optional

### DIFF
--- a/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.Identity/IdentityServiceCollectionExtensions.cs
@@ -57,13 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IdentityMarkerService>();
             services.TryAddScoped<IUserValidator<TUser>, UserValidator<TUser>>();
             services.TryAddScoped<IPasswordValidator<TUser>, PasswordValidator<TUser>>();
-            services.TryAddScoped<IPasswordHasher<TUser>, PasswordHasher<TUser>>();
-            services.TryAddScoped<ILookupNormalizer, UpperInvariantLookupNormalizer>();
             services.TryAddScoped<IRoleValidator<TRole>, RoleValidator<TRole>>();
-            // No interface for the error describer so we can add errors without rev'ing the interface
-            services.TryAddScoped<IdentityErrorDescriber>();
-            services.TryAddScoped<ISecurityStampValidator, SecurityStampValidator<TUser>>();
-            services.TryAddScoped<IUserClaimsPrincipalFactory<TUser>, UserClaimsPrincipalFactory<TUser, TRole>>();
             services.TryAddScoped<UserManager<TUser>, UserManager<TUser>>();
             services.TryAddScoped<SignInManager<TUser>, SignInManager<TUser>>();
             services.TryAddScoped<RoleManager<TRole>, RoleManager<TRole>>();

--- a/src/Microsoft.AspNet.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNet.Identity/SignInManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNet.Identity
     {
         private const string LoginProviderKey = "LoginProvider";
         private const string XsrfKey = "XsrfId";
+        private IHttpContextAccessor _contextAccessor;
 
         /// <summary>
         /// Creates a new instance of <see cref="SignInManager{TUser}"/>.
@@ -41,7 +42,7 @@ namespace Microsoft.AspNet.Identity
             {
                 throw new ArgumentNullException(nameof(userManager));
             }
-            if (contextAccessor == null || contextAccessor.HttpContext == null)
+            if (contextAccessor == null)
             {
                 throw new ArgumentNullException(nameof(contextAccessor));
             }
@@ -51,7 +52,7 @@ namespace Microsoft.AspNet.Identity
             }
 
             UserManager = userManager;
-            Context = contextAccessor.HttpContext;
+            _contextAccessor = contextAccessor;
             ClaimsFactory = claimsFactory;
             Options = optionsAccessor?.Value ?? new IdentityOptions();
             Logger = logger;
@@ -65,9 +66,10 @@ namespace Microsoft.AspNet.Identity
         /// </value>
         protected internal virtual ILogger Logger { get; set; }
         protected internal UserManager<TUser> UserManager { get; set; }
-        internal HttpContext Context { get; set; }
         internal IUserClaimsPrincipalFactory<TUser> ClaimsFactory { get; set; }
         internal IdentityOptions Options { get; set; }
+
+        internal HttpContext Context => _contextAccessor.HttpContext;
 
         /// <summary>
         /// Creates a <see cref="ClaimsPrincipal"/> for the specified <paramref name="user"/>, as an asynchronous operation.

--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNet.Identity
             }
             Store = store;
             Options = optionsAccessor?.Value ?? new IdentityOptions();
-            _context = contextAccessor?.HttpContext;
             PasswordHasher = passwordHasher;
             KeyNormalizer = keyNormalizer;
             ErrorDescriber = errors;
@@ -86,6 +85,7 @@ namespace Microsoft.AspNet.Identity
 
             if (services != null)
             {
+                _context = services.GetService<IHttpContextAccessor>()?.HttpContext;
                 foreach (var providerName in Options.Tokens.ProviderMap.Keys)
                 {
                     var provider = services.GetRequiredService(Options.Tokens.ProviderMap[providerName].ProviderType) as IUserTokenProvider<TUser>;

--- a/src/Microsoft.AspNet.Identity/UserManager.cs
+++ b/src/Microsoft.AspNet.Identity/UserManager.cs
@@ -72,10 +72,6 @@ namespace Microsoft.AspNet.Identity
                     UserValidators.Add(v);
                 }
             }
-            else
-            {
-                UserValidators.Add(new UserValidator<TUser>());
-            }
             var passwordValidators = services?.GetService<IEnumerable<IPasswordValidator<TUser>>>();
             if (passwordValidators != null)
             {
@@ -83,10 +79,6 @@ namespace Microsoft.AspNet.Identity
                 {
                     PasswordValidators.Add(v);
                 }
-            }
-            else
-            {
-                PasswordValidators.Add(new PasswordValidator<TUser>());
             }
 
             foreach (var providerName in Options.Tokens.ProviderMap.Keys)

--- a/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
@@ -94,9 +94,6 @@ namespace Microsoft.AspNet.Identity.Test
 
             var pwdValidator = provider.GetRequiredService<IPasswordValidator<TestUser>>() as PasswordValidator<TestUser>;
             Assert.NotNull(pwdValidator);
-
-            var hasher = provider.GetRequiredService<IPasswordHasher<TestUser>>() as PasswordHasher<TestUser>;
-            Assert.NotNull(hasher);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/IdentityBuilderTest.cs
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         private class MyUserManager : UserManager<TestUser>
         {
-            public MyUserManager(IUserStore<TestUser> store) : base(store, null, null, null, null, null, null, null, null, null) { }
+            public MyUserManager(IUserStore<TestUser> store) : base(store, null, null, null) { }
         }
 
         private class MyRoleManager : RoleManager<TestRole>

--- a/test/Microsoft.AspNet.Identity.Test/SignInManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/SignInManagerTest.cs
@@ -73,7 +73,6 @@ namespace Microsoft.AspNet.Identity.Test
             var userManager = MockHelpers.MockUserManager<TestUser>().Object;
             Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<TestUser>(userManager, null, null, null, null));
             var contextAccessor = new Mock<IHttpContextAccessor>();
-            Assert.Throws<ArgumentNullException>("contextAccessor", () => new SignInManager<TestUser>(userManager, contextAccessor.Object, null, null, null));
             var context = new Mock<HttpContext>();
             contextAccessor.Setup(a => a.HttpContext).Returns(context.Object);
             Assert.Throws<ArgumentNullException>("claimsFactory", () => new SignInManager<TestUser>(userManager, contextAccessor.Object, null, null, null));
@@ -352,7 +351,6 @@ namespace Microsoft.AspNet.Identity.Test
             //signInManager.Setup(s => s.SignInAsync(user, It.Is<AuthenticationProperties>(p => p.IsPersistent == isPersistent),
             //externalLogin? loginProvider : null)).Returns(Task.FromResult(0)).Verifiable();
             signInManager.Setup(s => s.SignInAsync(user, It.IsAny<AuthenticationProperties>(), null)).Returns(Task.FromResult(0)).Verifiable();
-            signInManager.Object.Context = context.Object;
 
             // Act
             await signInManager.Object.RefreshSignInAsync(user);

--- a/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.Identity.Test
 
         public class CustomUserManager : UserManager<TestUser>
         {
-            public CustomUserManager() : base(new Mock<IUserStore<TestUser>>().Object, null, null, null, null, null, null, null, null, null)
+            public CustomUserManager() : base(new Mock<IUserStore<TestUser>>().Object, null, null, null)
             { }
         }
 
@@ -694,7 +694,7 @@ namespace Microsoft.AspNet.Identity.Test
         public async Task ManagerPublicNullChecks()
         {
             Assert.Throws<ArgumentNullException>("store",
-                () => new UserManager<TestUser>(null, null, null, null, null, null, null, null, null, null));
+                () => new UserManager<TestUser>(null, null, null, null));
 
             var manager = MockHelpers.TestUserManager(new NotImplementedStore());
 

--- a/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
+++ b/test/Microsoft.AspNet.Identity.Test/UserManagerTest.cs
@@ -1417,7 +1417,6 @@ namespace Microsoft.AspNet.Identity.Test
                 .AddSingleton<IUserStore<TestUser>>(store.Object)
                 .AddIdentity<TestUser, TestRole>();
             services.AddLogging();
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             var manager = services.BuildServiceProvider().GetRequiredService<UserManager<TestUser>>();
 


### PR DESCRIPTION
cc @divega I think we should do this for most of the other services which we are adding defaults to via AddIdentity, the ctor should really only take the UserStore service 