### PR TITLE
Fix check of default value in ConvertIdToString if TKey is a class

### DIFF
--- a/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
+++ b/src/Microsoft.AspNet.Identity.EntityFramework/UserStore.cs
@@ -314,7 +314,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework
         /// <returns>An <see cref="string"/> representation of the provided <paramref name="id"/>.</returns>
         public virtual string ConvertIdToString(TKey id)
         {
-            if (id.Equals(default(TKey)))
+            if (Object.Equals(id, default(TKey)))
             {
                 return null;
             }


### PR DESCRIPTION
In the UserStore class of Microsoft.AspNet.Identity.EntityFramework project, the function ConvertIdToString checks the value of key passed as an argument to verify if it is "null". The type of the argument is the generic type TKey. If the type is a struct it is ok, but if the type is a class (like a String), the test will cause an NullException.