### PR TITLE
Refactor EF tests database creation/deletion

### DIFF
--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/CustomPocoTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/CustomPocoTest.cs
@@ -4,17 +4,20 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Identity.Test;
 using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Data.Entity;
 using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test
 {
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
-    public class CustomPocoTest
+    public class CustomPocoTest : IClassFixture<ScratchDatabaseFixture>
     {
-        private readonly string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=CustomUserContextTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;Connection Timeout=30";
+        private readonly ScratchDatabaseFixture _fixture;
+
+        public CustomPocoTest(ScratchDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+        }
 
         public class User<TKey> where TKey : IEquatable<TKey>
         {
@@ -30,7 +33,7 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
 
         public CustomDbContext<TKey> GetContext<TKey>() where TKey : IEquatable<TKey>
         {
-            return DbUtil.Create<CustomDbContext<TKey>>(ConnectionString);
+            return DbUtil.Create<CustomDbContext<TKey>>(_fixture.ConnectionString);
         }
 
         public CustomDbContext<TKey> CreateContext<TKey>(bool delete = false) where TKey : IEquatable<TKey>
@@ -44,30 +47,10 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             return db;
         }
 
-        [TestPriority(-1000)]
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
-        public void DropDatabaseStart()
-        {
-            DropDb();
-        }
-
-        [TestPriority(10000)]
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
-        public void DropDatabaseDone()
-        {
-            DropDb();
-        }
-
-        public void DropDb()
-        {
-            var db = GetContext<string>();
-            db.Database.EnsureDeleted();
-        }
-
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanUpdateNameGuid()
         {
             using (var db = CreateContext<Guid>(true))
@@ -85,7 +68,9 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanUpdateNameString()
         {
             using (var db = CreateContext<string>(true))
@@ -103,7 +88,9 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanCreateUserInt()
         {
             using (var db = CreateContext<int>(true))
@@ -119,7 +106,9 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanCreateUserIntViaSet()
         {
             using (var db = CreateContext<int>(true))
@@ -136,13 +125,15 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanUpdateNameInt()
         {
             using (var db = CreateContext<int>(true))
             {
                 var oldName = Guid.NewGuid().ToString();
-                var user = new User<int> { UserName = oldName};
+                var user = new User<int> { UserName = oldName };
                 db.Users.Add(user);
                 await db.SaveChangesAsync();
                 var newName = Guid.NewGuid().ToString();
@@ -154,13 +145,15 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)][OSSkipCondition(OperatingSystems.Linux)][OSSkipCondition(OperatingSystems.MacOSX)]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task CanUpdateNameIntWithSet()
         {
             using (var db = CreateContext<int>(true))
             {
                 var oldName = Guid.NewGuid().ToString();
-                var user = new User<int> { UserName = oldName};
+                var user = new User<int> { UserName = oldName };
                 db.Set<User<int>>().Add(user);
                 await db.SaveChangesAsync();
                 var newName = Guid.NewGuid().ToString();

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/DbUtil.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/DbUtil.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test
 {
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public static class DbUtil
     {
         public static IServiceCollection ConfigureDbServices(string connectionString, IServiceCollection services = null)
@@ -28,16 +27,10 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
             return services;
         }
 
-        public static IdentityDbContext Create(string connectionString)
-        {
-            return Create<IdentityDbContext>(connectionString);
-        }
-
         public static TContext Create<TContext>(string connectionString) where TContext : DbContext, new()
         {
             var serviceProvider = ConfigureDbServices<TContext>(connectionString).BuildServiceProvider();
             return serviceProvider.GetRequiredService<TContext>();
         }
-
     }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreGuidKeyTest.cs
@@ -25,17 +25,11 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
     }
 
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public class UserStoreGuidTest : SqlStoreTestBase<GuidUser, GuidRole, Guid>
     {
-        private readonly string _connectionString = @"Server=(localdb)\mssqllocaldb;Database=SqlUserStoreGuidTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;Connection Timeout=30";
-
-        public override string ConnectionString
+        public UserStoreGuidTest(ScratchDatabaseFixture fixture)
+            : base(fixture)
         {
-            get
-            {
-                return _connectionString;
-            }
         }
 
         public class ApplicationUserStore : UserStore<GuidUser, GuidRole, TestDbContext, Guid>

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreIntKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreIntKeyTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test
 {
@@ -22,17 +21,11 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
     }
 
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public class UserStoreIntTest : SqlStoreTestBase<IntUser, IntRole, int>
     {
-        private readonly string _connectionString = @"Server=(localdb)\mssqllocaldb;Database=SqlUserStoreIntTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;Connection Timeout=30";
-
-        public override string ConnectionString
+        public UserStoreIntTest(ScratchDatabaseFixture fixture)
+            : base(fixture)
         {
-            get
-            {
-                return _connectionString;
-            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreStringKeyTest.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/UserStoreStringKeyTest.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Xunit;
 
 namespace Microsoft.AspNet.Identity.EntityFramework.Test
 {
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public class StringUser : IdentityUser
     {
         public StringUser()
@@ -25,17 +23,11 @@ namespace Microsoft.AspNet.Identity.EntityFramework.Test
         }
     }
 
-    [TestCaseOrderer("Microsoft.AspNet.Identity.Test.PriorityOrderer", "Microsoft.AspNet.Identity.EntityFramework.Test")]
     public class UserStoreStringKeyTest : SqlStoreTestBase<StringUser, StringRole, string>
     {
-        private readonly string _connectionString = @"Server=(localdb)\mssqllocaldb;Database=SqlUserStoreStringTest" + DateTime.Now.Month + "-" + DateTime.Now.Day + "-" + DateTime.Now.Year + ";Trusted_Connection=True;Connection Timeout=30";
-
-        public override string ConnectionString
+        public UserStoreStringKeyTest(ScratchDatabaseFixture fixture)
+            : base(fixture)
         {
-            get
-            {
-                return _connectionString;
-            }
         }
     }
 }

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/EntityFrameworkServiceBuilderExtension.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/EntityFrameworkServiceBuilderExtension.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class EntityFrameworkServiceBuilderExtension
+    {
+        public static IServiceCollection ServiceCollection(this EntityFrameworkServicesBuilder services)
+            => services.GetInfrastructure();
+    }
+}

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/ScratchDatabaseFixture.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/ScratchDatabaseFixture.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Identity.EntityFramework.Test.Utilities;
+using Microsoft.Data.Entity.Internal;
+
+namespace Microsoft.AspNet.Identity.EntityFramework.Test
+{
+    public class ScratchDatabaseFixture : IDisposable
+    {
+        private LazyRef<SqlServerTestStore> _testStore;
+
+        public ScratchDatabaseFixture()
+        {
+            _testStore = new LazyRef<SqlServerTestStore>(() => SqlServerTestStore.CreateScratch());
+        }
+
+        public string ConnectionString => _testStore.Value.Connection.ConnectionString;
+
+        public void Dispose()
+        {
+            if (_testStore.HasValue)
+            {
+                _testStore.Value?.Dispose();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/SqlServerTestStore.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/SqlServerTestStore.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.IO;
+using System.Threading;
+
+namespace Microsoft.AspNet.Identity.EntityFramework.Test.Utilities
+{
+    public class SqlServerTestStore : IDisposable
+    {
+        public const int CommandTimeout = 90;
+
+        public static string CreateConnectionString(string name)
+        {
+            var connStrBuilder = new SqlConnectionStringBuilder(TestEnvironment.Config["Test:SqlServer:DefaultConnectionString"])
+            {
+                InitialCatalog = name
+            };
+
+            return connStrBuilder.ConnectionString;
+        }
+
+        public static SqlServerTestStore CreateScratch(bool createDatabase = true)
+            => new SqlServerTestStore(GetScratchDbName()).CreateTransient(createDatabase);
+
+        private SqlConnection _connection;
+        private readonly string _name;
+        private bool _deleteDatabase;
+
+        private SqlServerTestStore(string name)
+        {
+            _name = name;
+        }
+
+        private static string GetScratchDbName()
+        {
+            string name;
+            do
+            {
+                name = "Scratch_" + Guid.NewGuid();
+            } while (DatabaseExists(name)
+                     || DatabaseFilesExist(name));
+
+            return name;
+        }
+
+        private static void WaitForExists(SqlConnection connection)
+        {
+            var retryCount = 0;
+            while (true)
+            {
+                try
+                {
+                    connection.Open();
+
+                    connection.Close();
+
+                    return;
+                }
+                catch (SqlException e)
+                {
+                    if (++retryCount >= 30
+                        || (e.Number != 233 && e.Number != -2 && e.Number != 4060))
+                    {
+                        throw;
+                    }
+
+                    SqlConnection.ClearPool(connection);
+
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        private SqlServerTestStore CreateTransient(bool createDatabase)
+        {
+            _connection = new SqlConnection(CreateConnectionString(_name));
+
+            if (createDatabase)
+            {
+                using (var master = new SqlConnection(CreateConnectionString("master")))
+                {
+                    master.Open();
+                    using (var command = master.CreateCommand())
+                    {
+                        command.CommandTimeout = CommandTimeout;
+                        command.CommandText = $"{Environment.NewLine}CREATE DATABASE [{_name}]";
+
+                        command.ExecuteNonQuery();
+
+                        WaitForExists(_connection);
+                    }
+                }
+                _connection.Open();
+            }
+
+            _deleteDatabase = true;
+            return this;
+        }
+
+        private static bool DatabaseExists(string name)
+        {
+            using (var master = new SqlConnection(CreateConnectionString("master")))
+            {
+                master.Open();
+
+                using (var command = master.CreateCommand())
+                {
+                    command.CommandTimeout = CommandTimeout;
+                    command.CommandText = $@"SELECT COUNT(*) FROM sys.databases WHERE name = N'{name}'";
+
+                    return (int) command.ExecuteScalar() > 0;
+                }
+            }
+        }
+
+        private static bool DatabaseFilesExist(string name)
+        {
+            var userFolder = Environment.GetEnvironmentVariable("USERPROFILE") ??
+                             Environment.GetEnvironmentVariable("HOME");
+            return userFolder != null
+                   && (File.Exists(Path.Combine(userFolder, name + ".mdf"))
+                       || File.Exists(Path.Combine(userFolder, name + "_log.ldf")));
+        }
+
+        private void DeleteDatabase(string name)
+        {
+            using (var master = new SqlConnection(CreateConnectionString("master")))
+            {
+                master.Open();
+
+                using (var command = master.CreateCommand())
+                {
+                    command.CommandTimeout = CommandTimeout;
+                        // Query will take a few seconds if (and only if) there are active connections
+
+                    // SET SINGLE_USER will close any open connections that would prevent the drop
+                    command.CommandText
+                        = string.Format(@"IF EXISTS (SELECT * FROM sys.databases WHERE name = N'{0}')
+                                          BEGIN
+                                              ALTER DATABASE [{0}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                                              DROP DATABASE [{0}];
+                                          END", name);
+
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public DbConnection Connection => _connection;
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+
+            if (_deleteDatabase)
+            {
+                DeleteDatabase(_name);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/TestEnvironment.cs
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/Utilities/TestEnvironment.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNet.Identity.EntityFramework.Test.Utilities
+{
+    public static class TestEnvironment
+    {
+        public static IConfiguration Config { get; }
+
+        static TestEnvironment()
+        {
+            var configBuilder = new ConfigurationBuilder()
+                .SetBasePath(".")
+                .AddJsonFile("config.json", optional: true)
+                .AddJsonFile("config.test.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Config = configBuilder.Build();
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Identity.EntityFramework.Test/config.json
+++ b/test/Microsoft.AspNet.Identity.EntityFramework.Test/config.json
@@ -1,0 +1,7 @@
+﻿{
+  "Test": {
+    "SqlServer": {
+      "DefaultConnectionString":  "Server=(localdb)\\MSSqlLocaldb;Integrated Security=true;MultipleActiveResultSets=true;Connect Timeout=30"
+    }
+  }
+}

--- a/test/Shared/UserManagerTestBase.cs
+++ b/test/Shared/UserManagerTestBase.cs
@@ -1458,7 +1458,8 @@ namespace Microsoft.AspNet.Identity.Test
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Fails due to threading bugs in Mono")]
         public async Task CanGetRolesForUser()
         {
             if (ShouldSkipDbTests())
@@ -2013,7 +2014,8 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(DateTimeOffset.Parse("01/01/2014"), await userMgr.GetLockoutEndDateAsync(user));
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Fails due to threading bugs in Mono")]
         public async Task CanGetUsersWithClaims()
         {
             if (ShouldSkipDbTests())
@@ -2038,7 +2040,8 @@ namespace Microsoft.AspNet.Identity.Test
             Assert.Equal(0, (await manager.GetUsersForClaimAsync(new Claim("123", "456"))).Count);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Fails due to threading bugs in Mono")]
         public async Task CanGetUsersInRole()
         {
             if (ShouldSkipDbTests())


### PR DESCRIPTION
Use fixtures instead of test ordering to manage creation/deletion of scratch databases.

Fix #678 

cc @divega 