### PR TITLE
Add + to allowed username characters by default

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/UserOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The list of allowed characters in the username used to validate user names.
         /// </value>
-        public string AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@";
+        public string AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
 
         /// <summary>
         /// Gets or sets a flag indicating whether the application requires unique emails for its users.

--- a/test/Microsoft.AspNetCore.Identity.Test/IdentityOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/IdentityOptionsTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.True(options.Password.RequireUppercase);
             Assert.Equal(6, options.Password.RequiredLength);
 
-            Assert.Equal("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@", options.User.AllowedUserNameCharacters);
+            Assert.Equal("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+", options.User.AllowedUserNameCharacters);
             Assert.False(options.User.RequireUniqueEmail);
 
             Assert.Equal(ClaimTypes.Role, options.ClaimsIdentity.RoleClaimType);
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.Equal(usernameClaimType, options.ClaimsIdentity.UserNameClaimType);
             Assert.Equal(securityStampClaimType, options.ClaimsIdentity.SecurityStampClaimType);
             Assert.True(options.User.RequireUniqueEmail);
-            Assert.Equal("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@", options.User.AllowedUserNameCharacters);
+            Assert.Equal("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+", options.User.AllowedUserNameCharacters);
             Assert.False(options.Password.RequireDigit);
             Assert.False(options.Password.RequireLowercase);
             Assert.False(options.Password.RequireNonAlphanumeric);

--- a/test/Microsoft.AspNetCore.Identity.Test/UserValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/UserValidatorTest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         [InlineData("hao", true)]
         [InlineData("test123", true)]
         [InlineData("hyphen-yes@foo-bar.com", true)]
+        [InlineData("+plus+yes+@foo-bar.com", true)]
         [InlineData("!noway", false)]
         [InlineData("foo@boz#.com", false)]
         public async Task DefaultAlphaNumericOnlyUserNameValidation(string userName, bool expectSuccess)


### PR DESCRIPTION
Fixes https://github.com/aspnet/Identity/issues/742

cc @divega @blowdart 