### PR TITLE
Remove usage of IOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/BuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Identity/BuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new InvalidOperationException(Resources.MustCallAddIdentity);
             }
 
-            var options = app.ApplicationServices.GetRequiredService<IOptions<IdentityOptions>>().Value;
+            var options = app.ApplicationServices.GetRequiredService<IdentityOptions>();
             app.UseCookieAuthentication(options.Cookies.ExternalCookie);
             app.UseCookieAuthentication(options.Cookies.TwoFactorRememberMeCookie);
             app.UseCookieAuthentication(options.Cookies.TwoFactorUserIdCookie);

--- a/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -11,6 +13,18 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class IdentityOptions
     {
+        public IdentityOptions(IEnumerable<IConfigureOptions<IdentityOptions>> configureOptions = null)
+        {
+            if (configureOptions != null)
+            {
+                foreach (var configure in configureOptions)
+                {
+                    configure.Configure(this);
+                }
+            }
+        }
+
+
         /// <summary>
         /// Gets or sets the <see cref="ClaimsIdentityOptions"/> for the identity system.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Hosting doesn't add IHttpContextAccessor by default
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             // Identity services
+            services.TryAddSingleton<IdentityOptions>();
             services.TryAddSingleton<IdentityMarkerService>();
             services.TryAddScoped<IUserValidator<TUser>, UserValidator<TUser>>();
             services.TryAddScoped<IPasswordValidator<TUser>, PasswordValidator<TUser>>();

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Identity
         private readonly SignInManager<TUser> _signInManager;
         private readonly IdentityOptions _options;
 
-        public SecurityStampValidator(IOptions<IdentityOptions> options, SignInManager<TUser> signInManager)
+        public SecurityStampValidator(IdentityOptions options, SignInManager<TUser> signInManager)
         {
             if (options == null)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Identity
                 throw new ArgumentNullException(nameof(signInManager));
             }
             _signInManager = signInManager;
-            _options = options.Value;
+            _options = options;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -30,12 +30,12 @@ namespace Microsoft.AspNetCore.Identity
         /// <param name="userManager">An instance of <see cref="UserManager"/> used to retrieve users from and persist users.</param>
         /// <param name="contextAccessor">The accessor used to access the <see cref="HttpContext"/>.</param>
         /// <param name="claimsFactory">The factory to use to create claims principals for a user.</param>
-        /// <param name="optionsAccessor">The accessor used to access the <see cref="IdentityOptions"/>.</param>
+        /// <param name="options">The <see cref="IdentityOptions"/>.</param>
         /// <param name="logger">The logger used to log messages, warnings and errors.</param>
         public SignInManager(UserManager<TUser> userManager,
             IHttpContextAccessor contextAccessor,
             IUserClaimsPrincipalFactory<TUser> claimsFactory,
-            IOptions<IdentityOptions> optionsAccessor,
+            IdentityOptions options,
             ILogger<SignInManager<TUser>> logger)
         {
             if (userManager == null)
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Identity
             UserManager = userManager;
             _contextAccessor = contextAccessor;
             ClaimsFactory = claimsFactory;
-            Options = optionsAccessor?.Value ?? new IdentityOptions();
+            Options = options ?? new IdentityOptions();
             Logger = logger;
         }
 

--- a/src/Microsoft.AspNetCore.Identity/UserClaimsPrincipalFactory.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserClaimsPrincipalFactory.cs
@@ -23,11 +23,11 @@ namespace Microsoft.AspNetCore.Identity
         /// </summary>
         /// <param name="userManager">The <see cref="UserManager{TUser}"/> to retrieve user information from.</param>
         /// <param name="roleManager">The <see cref="RoleManager{TRole}"/> to retrieve a user's roles from.</param>
-        /// <param name="optionsAccessor">The configured <see cref="IdentityOptions"/>.</param>
+        /// <param name="options">The configured <see cref="IdentityOptions"/>.</param>
         public UserClaimsPrincipalFactory(
             UserManager<TUser> userManager, 
             RoleManager<TRole> roleManager, 
-            IOptions<IdentityOptions> optionsAccessor)
+            IdentityOptions options)
         {
             if (userManager == null)
             {
@@ -37,13 +37,13 @@ namespace Microsoft.AspNetCore.Identity
             {
                 throw new ArgumentNullException(nameof(roleManager));
             }
-            if (optionsAccessor == null || optionsAccessor.Value == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(optionsAccessor));
+                throw new ArgumentNullException(nameof(options));
             }
             UserManager = userManager;
             RoleManager = roleManager;
-            Options = optionsAccessor.Value;
+            Options = options;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Identity
         /// Constructs a new instance of <see cref="UserManager{TUser}"/>.
         /// </summary>
         /// <param name="store">The persistence store the manager will operate over.</param>
-        /// <param name="optionsAccessor">The accessor used to access the <see cref="IdentityOptions"/>.</param>
+        /// <param name="options">The <see cref="IdentityOptions"/>.</param>
         /// <param name="passwordHasher">The password hashing implementation to use when saving passwords.</param>
         /// <param name="userValidators">A collection of <see cref="IUserValidator{TUser}"/> to validate users against.</param>
         /// <param name="passwordValidators">A collection of <see cref="IPasswordValidator{TUser}"/> to validate passwords against.</param>
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <param name="services">The <see cref="IServiceProvider"/> used to resolve services.</param>
         /// <param name="logger">The logger used to log messages, warnings and errors.</param>
         public UserManager(IUserStore<TUser> store,
-            IOptions<IdentityOptions> optionsAccessor,
+            IdentityOptions options,
             IPasswordHasher<TUser> passwordHasher,
             IEnumerable<IUserValidator<TUser>> userValidators,
             IEnumerable<IPasswordValidator<TUser>> passwordValidators,
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Identity
                 throw new ArgumentNullException(nameof(store));
             }
             Store = store;
-            Options = optionsAccessor?.Value ?? new IdentityOptions();
+            Options = options ?? new IdentityOptions();
             PasswordHasher = passwordHasher;
             KeyNormalizer = keyNormalizer;
             ErrorDescriber = errors;

--- a/test/Microsoft.AspNetCore.Identity.Test/IdentityBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/IdentityBuilderTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             services.AddIdentity<TestUser,TestRole>().AddDefaultTokenProviders();
 
             var provider = services.BuildServiceProvider();
-            var tokenProviders = provider.GetRequiredService<IOptions<IdentityOptions>>().Value.Tokens.ProviderMap.Values;
+            var tokenProviders = provider.GetRequiredService<IdentityOptions>().Tokens.ProviderMap.Values;
             Assert.Equal(3, tokenProviders.Count());
         }
 

--- a/test/Microsoft.AspNetCore.Identity.Test/IdentityOptionsTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/IdentityOptionsTest.cs
@@ -68,9 +68,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var services = new ServiceCollection();
             services.AddIdentity<TestUser,TestRole>();
             services.Configure<IdentityOptions>(config.GetSection("identity"));
-            var accessor = services.BuildServiceProvider().GetRequiredService<IOptions<IdentityOptions>>();
-            Assert.NotNull(accessor);
-            var options = accessor.Value;
+            var options = services.BuildServiceProvider().GetRequiredService<IdentityOptions>();
             Assert.Equal(roleClaimType, options.ClaimsIdentity.RoleClaimType);
             Assert.Equal(useridClaimType, options.ClaimsIdentity.UserIdClaimType);
             Assert.Equal(usernameClaimType, options.ClaimsIdentity.UserNameClaimType);
@@ -100,9 +98,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var services = new ServiceCollection();
             services.Configure<IdentityOptions>(config.GetSection("identity"));
             services.AddIdentity<TestUser, TestRole>(o => { o.User.RequireUniqueEmail = false; o.Lockout.MaxFailedAccessAttempts++; });
-            var accessor = services.BuildServiceProvider().GetRequiredService<IOptions<IdentityOptions>>();
-            Assert.NotNull(accessor);
-            var options = accessor.Value;
+            var options = services.BuildServiceProvider().GetRequiredService<IdentityOptions>();
             Assert.False(options.User.RequireUniqueEmail);
             Assert.Equal(1001, options.Lockout.MaxFailedAccessAttempts);
         }
@@ -117,9 +113,7 @@ namespace Microsoft.AspNetCore.Identity.Test
 
             var setup = serviceProvider.GetRequiredService<IConfigureOptions<IdentityOptions>>();
             Assert.NotNull(setup);
-            var optionsGetter = serviceProvider.GetRequiredService<IOptions<IdentityOptions>>();
-            Assert.NotNull(optionsGetter);
-            var myOptions = optionsGetter.Value;
+            var myOptions = services.BuildServiceProvider().GetRequiredService<IdentityOptions>();
             Assert.True(myOptions.Password.RequireLowercase);
             Assert.True(myOptions.Password.RequireDigit);
             Assert.True(myOptions.Password.RequireNonAlphanumeric);
@@ -133,11 +127,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var services = new ServiceCollection();
             services.AddIdentity<TestUser,TestRole>(options => options.User.RequireUniqueEmail = true);
             var serviceProvider = services.BuildServiceProvider();
-
-            var optionsGetter = serviceProvider.GetRequiredService<IOptions<IdentityOptions>>();
-            Assert.NotNull(optionsGetter);
-
-            var myOptions = optionsGetter.Value;
+            var myOptions = services.BuildServiceProvider().GetRequiredService<IdentityOptions>();
             Assert.True(myOptions.User.RequireUniqueEmail);
         }
     }

--- a/test/Microsoft.AspNetCore.Identity.Test/SecurityStampValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/SecurityStampValidatorTest.cs
@@ -38,30 +38,28 @@ namespace Microsoft.AspNetCore.Identity.Test
             var user = new TestUser("test");
             var userManager = MockHelpers.MockUserManager<TestUser>();
             var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
-            var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
+            var options = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var httpContext = new Mock<HttpContext>();
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
-            var id = new ClaimsIdentity(identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+            var id = new ClaimsIdentity(options.Cookies.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
             var principal = new ClaimsPrincipal(id);
 
             var properties = new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow, IsPersistent = isPersistent };
             var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
-                contextAccessor.Object, claimsManager.Object, options.Object, null);
+                contextAccessor.Object, claimsManager.Object, options, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user).Verifiable();
             signInManager.Setup(s => s.CreateUserPrincipalAsync(user)).ReturnsAsync(principal).Verifiable();
             var services = new ServiceCollection();
-            services.AddSingleton(options.Object);
+            services.AddSingleton(options);
             services.AddSingleton(signInManager.Object);
-            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options.Object, signInManager.Object));
+            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options, signInManager.Object));
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
 
             var ticket = new AuthenticationTicket(principal, 
                 properties, 
-                identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+                options.Cookies.ApplicationCookieAuthenticationScheme);
             var context = new CookieValidatePrincipalContext(httpContext.Object, ticket, new CookieAuthenticationOptions());
             Assert.NotNull(context.Properties);
             Assert.NotNull(context.Options);
@@ -78,26 +76,24 @@ namespace Microsoft.AspNetCore.Identity.Test
             var user = new TestUser("test");
             var userManager = MockHelpers.MockUserManager<TestUser>();
             var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
-            var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
+            var options = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var httpContext = new Mock<HttpContext>();
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
             var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
-                contextAccessor.Object, claimsManager.Object, options.Object, null);
+                contextAccessor.Object, claimsManager.Object, options, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(null).Verifiable();
             var services = new ServiceCollection();
-            services.AddSingleton(options.Object);
+            services.AddSingleton(options);
             services.AddSingleton(signInManager.Object);
-            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options.Object, signInManager.Object));
+            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options, signInManager.Object));
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
-            var id = new ClaimsIdentity(identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+            var id = new ClaimsIdentity(options.Cookies.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
 
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
                 new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow },
-                identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+                options.Cookies.ApplicationCookieAuthenticationScheme);
             var context = new CookieValidatePrincipalContext(httpContext.Object, ticket, new CookieAuthenticationOptions());
             Assert.NotNull(context.Properties);
             Assert.NotNull(context.Options);
@@ -114,25 +110,23 @@ namespace Microsoft.AspNetCore.Identity.Test
             var httpContext = new Mock<HttpContext>();
             var userManager = MockHelpers.MockUserManager<TestUser>();
             var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
-            var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
+            var options = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.Zero };
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
             var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
-                contextAccessor.Object, claimsManager.Object, options.Object, null);
+                contextAccessor.Object, claimsManager.Object, options, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(null).Verifiable();
             var services = new ServiceCollection();
-            services.AddSingleton(options.Object);
+            services.AddSingleton(options);
             services.AddSingleton(signInManager.Object);
-            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options.Object, signInManager.Object));
+            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options, signInManager.Object));
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
-            var id = new ClaimsIdentity(identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+            var id = new ClaimsIdentity(options.Cookies.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
 
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
                 new AuthenticationProperties(),
-                identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+                options.Cookies.ApplicationCookieAuthenticationScheme);
             var context = new CookieValidatePrincipalContext(httpContext.Object, ticket, new CookieAuthenticationOptions());
             Assert.NotNull(context.Properties);
             Assert.NotNull(context.Options);
@@ -149,26 +143,24 @@ namespace Microsoft.AspNetCore.Identity.Test
             var httpContext = new Mock<HttpContext>();
             var userManager = MockHelpers.MockUserManager<TestUser>();
             var claimsManager = new Mock<IUserClaimsPrincipalFactory<TestUser>>();
-            var identityOptions = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.FromDays(1) };
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
+            var options = new IdentityOptions { SecurityStampValidationInterval = TimeSpan.FromDays(1) };
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
             var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
-                contextAccessor.Object, claimsManager.Object, options.Object, null);
+                contextAccessor.Object, claimsManager.Object, options, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).Throws(new Exception("Shouldn't be called"));
             signInManager.Setup(s => s.SignInAsync(user, false, null)).Throws(new Exception("Shouldn't be called"));
             var services = new ServiceCollection();
-            services.AddSingleton(options.Object);
+            services.AddSingleton(options);
             services.AddSingleton(signInManager.Object);
-            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options.Object, signInManager.Object));
+            services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<TestUser>(options, signInManager.Object));
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
-            var id = new ClaimsIdentity(identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+            var id = new ClaimsIdentity(options.Cookies.ApplicationCookieAuthenticationScheme);
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
 
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
                 new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow },
-                identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
+                options.Cookies.ApplicationCookieAuthenticationScheme);
             var context = new CookieValidatePrincipalContext(httpContext.Object, ticket, new CookieAuthenticationOptions());
             Assert.NotNull(context.Properties);
             Assert.NotNull(context.Options);

--- a/test/Microsoft.AspNetCore.Identity.Test/SignInManagerTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/SignInManagerTest.cs
@@ -119,13 +119,11 @@ namespace Microsoft.AspNetCore.Identity.Test
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(context.Object);
             var roleManager = MockHelpers.MockRoleManager<TestRole>();
-            var identityOptions = new IdentityOptions();
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
-            var claimsFactory = new UserClaimsPrincipalFactory<TestUser, TestRole>(manager.Object, roleManager.Object, options.Object);
+            var options = new IdentityOptions();
+            var claimsFactory = new UserClaimsPrincipalFactory<TestUser, TestRole>(manager.Object, roleManager.Object, options);
             var logStore = new StringBuilder();
             var logger = MockHelpers.MockILogger<SignInManager<TestUser>>(logStore);
-            var helper = new SignInManager<TestUser>(manager.Object, contextAccessor.Object, claimsFactory, options.Object, logger.Object);
+            var helper = new SignInManager<TestUser>(manager.Object, contextAccessor.Object, claimsFactory, options, logger.Object);
 
             // Act
             var result = await helper.PasswordSignInAsync(user.UserName, "bogus", false, false);
@@ -147,16 +145,14 @@ namespace Microsoft.AspNetCore.Identity.Test
             return manager;
         }
 
-        private static SignInManager<TestUser> SetupSignInManager(UserManager<TestUser> manager, HttpContext context, StringBuilder logStore = null, IdentityOptions identityOptions = null)
+        private static SignInManager<TestUser> SetupSignInManager(UserManager<TestUser> manager, HttpContext context, StringBuilder logStore = null, IdentityOptions options = null)
         {
             var contextAccessor = new Mock<IHttpContextAccessor>();
             contextAccessor.Setup(a => a.HttpContext).Returns(context);
             var roleManager = MockHelpers.MockRoleManager<TestRole>();
-            identityOptions = identityOptions ?? new IdentityOptions();
-            var options = new Mock<IOptions<IdentityOptions>>();
-            options.Setup(a => a.Value).Returns(identityOptions);
-            var claimsFactory = new UserClaimsPrincipalFactory<TestUser, TestRole>(manager, roleManager.Object, options.Object);
-            var sm = new SignInManager<TestUser>(manager, contextAccessor.Object, claimsFactory, options.Object, null);
+            options = options ?? new IdentityOptions();
+            var claimsFactory = new UserClaimsPrincipalFactory<TestUser, TestRole>(manager, roleManager.Object, options);
+            var sm = new SignInManager<TestUser>(manager, contextAccessor.Object, claimsFactory, options, null);
             sm.Logger = MockHelpers.MockILogger<SignInManager<TestUser>>(logStore ?? new StringBuilder()).Object;
             return sm;
         }

--- a/test/Microsoft.AspNetCore.Identity.Test/UserClaimsPrincipalFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/UserClaimsPrincipalFactoryTest.cs
@@ -19,12 +19,10 @@ namespace Microsoft.AspNetCore.Identity.Test
         {
             var userManager = MockHelpers.MockUserManager<TestUser>().Object;
             var roleManager = MockHelpers.MockRoleManager<TestRole>().Object;
-            var options = new Mock<IOptions<IdentityOptions>>();
-            Assert.Throws<ArgumentNullException>("optionsAccessor",
-                () => new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager, roleManager, options.Object));
-            var identityOptions = new IdentityOptions();
-            options.Setup(a => a.Value).Returns(identityOptions);
-            var factory = new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager, roleManager, options.Object);
+            Assert.Throws<ArgumentNullException>("options",
+                () => new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager, roleManager, null));
+            var options = new IdentityOptions();
+            var factory = new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager, roleManager, options);
             await Assert.ThrowsAsync<ArgumentNullException>("user",
                 async () => await factory.CreateAsync(null));
         }
@@ -71,10 +69,8 @@ namespace Microsoft.AspNetCore.Identity.Test
                 roleManager.Setup(m => m.GetClaimsAsync(local)).ReturnsAsync(localClaims);
             }
 
-            var options = new Mock<IOptions<IdentityOptions>>();
             var identityOptions = new IdentityOptions();
-            options.Setup(a => a.Value).Returns(identityOptions);
-            var factory = new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager.Object, roleManager.Object, options.Object);
+            var factory = new UserClaimsPrincipalFactory<TestUser, TestRole>(userManager.Object, roleManager.Object, identityOptions);
 
             // Act
             var principal = await factory.CreateAsync(user);

--- a/test/Shared/MockHelpers.cs
+++ b/test/Shared/MockHelpers.cs
@@ -65,16 +65,14 @@ namespace Microsoft.AspNetCore.Identity.Test
         public static UserManager<TUser> TestUserManager<TUser>(IUserStore<TUser> store = null) where TUser : class
         {
             store = store ?? new Mock<IUserStore<TUser>>().Object;
-            var options = new Mock<IOptions<IdentityOptions>>();
-            var idOptions = new IdentityOptions();
-            idOptions.Lockout.AllowedForNewUsers = false;
-            options.Setup(o => o.Value).Returns(idOptions);
+            var options = new IdentityOptions();
+            options.Lockout.AllowedForNewUsers = false;
             var userValidators = new List<IUserValidator<TUser>>();
             var validator = new Mock<IUserValidator<TUser>>();
             userValidators.Add(validator.Object);
             var pwdValidators = new List<PasswordValidator<TUser>>();
             pwdValidators.Add(new PasswordValidator<TUser>());
-            var userManager = new UserManager<TUser>(store, options.Object, new PasswordHasher<TUser>(),
+            var userManager = new UserManager<TUser>(store, options, new PasswordHasher<TUser>(),
                 userValidators, pwdValidators, new UpperInvariantLookupNormalizer(),
                 new IdentityErrorDescriber(), null,
                 new Mock<ILogger<UserManager<TUser>>>().Object);


### PR DESCRIPTION
Looks like I can do this in reverse, removing usage from all places, before removing the feature since we aren't using the new sugar...

For identity, with this change we could consider making the main IdentityOptions actually consume the sub options as services instead of new'ing up instances of each of the sub options like Password/UserOptions.  Something to consider now that our options are services...

@divega @blowdart 