### PR TITLE
Redress cookie name

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/IdentityCookieOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityCookieOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Identity
     /// </summary>
     public class IdentityCookieOptions
     {
-        private static readonly string CookiePrefix = ".AspNetCore.Identity";
+        private static readonly string CookiePrefix = "Identity";
         private static readonly string DefaultApplicationScheme = CookiePrefix + ".Application";
         private static readonly string DefaultExternalScheme = CookiePrefix + ".External";
         private static readonly string DefaultTwoFactorRememberMeScheme = CookiePrefix + ".TwoFactorRememberMe";


### PR DESCRIPTION
#763 

As part of fixing MusicStore tests in https://github.com/aspnet/MusicStore/pull/601, @natemcmaster found that we are not setting the cookie names correctly for cookies used by Identity. The reason for this is in the referenced issue. 

cc @Tratcher @HaoK 