### PR TITLE
Update IdentityDbContext constructors to reflect EF changes

### DIFF
--- a/samples/IdentitySample.Mvc/Startup.cs
+++ b/samples/IdentitySample.Mvc/Startup.cs
@@ -42,9 +42,7 @@ namespace IdentitySample
         public void ConfigureServices(IServiceCollection services)
         {
             // Add framework services.
-            services.AddEntityFramework()
-                .AddSqlServer()
-                .AddDbContext<ApplicationDbContext>(options =>
+            services.AddDbContext<ApplicationDbContext>(options =>
                     options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
 
             services.AddIdentity<ApplicationUser, IdentityRole>(options => {

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityDbContext.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityDbContext.cs
@@ -20,24 +20,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider) : base(serviceProvider)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="options">The options to be used by a <see cref="DbContext"/>.</param>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider, DbContextOptions options) : base(serviceProvider, options)
-        { }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="IdentityDbContext" /> class.
         /// </summary>
-        public IdentityDbContext()
+        protected IdentityDbContext()
         { }
     }
 
@@ -55,24 +40,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider) : base(serviceProvider)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="options">The options to be used by a <see cref="DbContext"/>.</param>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider, DbContextOptions options) : base(serviceProvider, options)
-        { }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="IdentityDbContext" /> class.
         /// </summary>
-        public IdentityDbContext()
+        protected IdentityDbContext()
         { }
     }
 
@@ -95,24 +65,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider) : base(serviceProvider)
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IdentityDbContext" /> class using an <see cref="IServiceProvider" />.
-        /// </summary>
-        /// <param name="options">The options to be used by a <see cref="DbContext"/>.</param>
-        /// <param name="serviceProvider"> The service provider to be used.</param>
-        public IdentityDbContext(IServiceProvider serviceProvider, DbContextOptions options) : base(serviceProvider, options)
-        { }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="IdentityDbContext" /> class.
         /// </summary>
-        public IdentityDbContext()
+        protected IdentityDbContext()
         { }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/InMemoryContext.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/InMemoryContext.cs
@@ -3,18 +3,23 @@
 
 using System;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
 {
     public class InMemoryContext :
         InMemoryContext<IdentityUser, IdentityRole, string>
     {
+        public InMemoryContext(DbContextOptions options) : base(options)
+        { }
     }
 
     public class InMemoryContext<TUser> :
         InMemoryContext<TUser, IdentityRole, string>
         where TUser : IdentityUser
     {
+        public InMemoryContext(DbContextOptions options) : base(options)
+        { }
     }
 
     public class InMemoryContext<TUser, TRole, TKey> : IdentityDbContext<TUser,TRole,TKey>
@@ -22,7 +27,8 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
     {
-        public InMemoryContext() { }
+        public InMemoryContext(DbContextOptions options) : base(options)
+        { }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/InMemoryEFUserStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/InMemoryEFUserStoreTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Identity.Test;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
@@ -12,7 +14,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
     {
         protected override object CreateTestContext()
         {
-            return new InMemoryContext();
+            return new InMemoryContext(new DbContextOptionsBuilder().Options);
         }
 
         protected override void AddUserStore(IServiceCollection services, object context = null)

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/RoleStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/RoleStoreTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity.Test;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -23,7 +25,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         public async Task CanCreateRoleWithSingletonManager()
         {
             var services = TestIdentityFactory.CreateTestServices();
-            services.AddEntityFramework().AddInMemoryDatabase();
+            services.AddAddEntityFrameworkInMemoryDatabase();
             services.AddTransient<InMemoryContext>();
             services.AddTransient<IRoleStore<IdentityRole>, RoleStore<IdentityRole, InMemoryContext>>();
             services.AddSingleton<RoleManager<IdentityRole>>();
@@ -36,7 +38,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         [Fact]
         public async Task RoleStoreMethodsThrowWhenDisposedTest()
         {
-            var store = new RoleStore<IdentityRole>(new InMemoryContext());
+            var store = new RoleStore<IdentityRole>(new InMemoryContext(new DbContextOptionsBuilder().Options));
             store.Dispose();
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.FindByIdAsync(null));
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.FindByNameAsync(null));
@@ -52,7 +54,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         public async Task RoleStorePublicNullCheckTest()
         {
             Assert.Throws<ArgumentNullException>("context", () => new RoleStore<IdentityRole>(null));
-            var store = new RoleStore<IdentityRole>(new InMemoryContext());
+            var store = new RoleStore<IdentityRole>(new InMemoryContext(new DbContextOptionsBuilder().Options));
             await Assert.ThrowsAsync<ArgumentNullException>("role", async () => await store.GetRoleIdAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("role", async () => await store.GetRoleNameAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("role", async () => await store.SetRoleNameAsync(null, null));

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/TestIdentityFactory.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/TestIdentityFactory.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
@@ -12,10 +14,10 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test
         public static InMemoryContext CreateContext()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryDatabase();
+            services.AddAddEntityFrameworkInMemoryDatabase();
             var serviceProvider = services.BuildServiceProvider();
 
-            var db = new InMemoryContext();
+            var db = new InMemoryContext(new DbContextOptionsBuilder().Options);
             db.Database.EnsureCreated();
 
             return db;

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/CustomPocoTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/CustomPocoTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
@@ -27,6 +28,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
 
         public class CustomDbContext<TKey> : DbContext where TKey : IEquatable<TKey>
         {
+            public CustomDbContext(DbContextOptions options) : base(options)
+            { }
+
             public DbSet<User<TKey>> Users { get; set; }
 
         }

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/DbUtil.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/DbUtil.cs
@@ -23,11 +23,11 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
                 services = new ServiceCollection();
             }
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-            services.AddEntityFramework().AddSqlServer().AddDbContext<TContext>(options => options.UseSqlServer(connectionString));
+            services.AddDbContext<TContext>(options => options.UseSqlServer(connectionString));
             return services;
         }
 
-        public static TContext Create<TContext>(string connectionString) where TContext : DbContext, new()
+        public static TContext Create<TContext>(string connectionString) where TContext : DbContext
         {
             var serviceProvider = ConfigureDbServices<TContext>(connectionString).BuildServiceProvider();
             return serviceProvider.GetRequiredService<TContext>();

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/DefaultPocoTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/DefaultPocoTest.cs
@@ -24,8 +24,6 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
             var services = new ServiceCollection();
 
             services
-                .AddEntityFramework()
-                .AddSqlServer()
                 .AddDbContext<IdentityDbContext>(o => o.UseSqlServer(fixture.ConnectionString))
                 .ServiceCollection()
                 .AddIdentity<IdentityUser, IdentityRole>()

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserStoreTest.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity.Test;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -25,7 +27,11 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
         protected override bool ShouldSkipDbTests()
             => TestPlatformHelper.IsMono || !TestPlatformHelper.IsWindows;
 
-        public class ApplicationDbContext : IdentityDbContext<ApplicationUser> { }
+        public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+        {
+            public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+            { }
+        }
 
         [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
@@ -84,7 +90,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
         [Fact]
         public async Task SqlUserStoreMethodsThrowWhenDisposedTest()
         {
-            var store = new UserStore(new IdentityDbContext());
+            var store = new UserStore(new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().Options));
             store.Dispose();
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.AddClaimsAsync(null, null));
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.AddLoginAsync(null, null));
@@ -118,7 +124,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
         public async Task UserStorePublicNullCheckTest()
         {
             Assert.Throws<ArgumentNullException>("context", () => new UserStore(null));
-            var store = new UserStore(new IdentityDbContext());
+            var store = new UserStore(new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().Options));
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetUserIdAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetUserNameAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.SetUserNameAsync(null, null));


### PR DESCRIPTION
EF now has a parameterless constructor that can only be used when a derived context has OnConfiguring and is hence protected, and a constructor that takes a DbContextOptions.

@divega 