### PR TITLE
Minor fix in description for LockoutEnabled property.

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityUser.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityUser.cs
@@ -127,9 +127,9 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         public virtual DateTimeOffset? LockoutEnd { get; set; }
 
         /// <summary>
-        /// Gets or sets a flag indicating if this user is locked out.
+        /// Gets or sets a flag indicating if the user could be locked out.
         /// </summary>
-        /// <value>True if the user is locked out, otherwise false.</value>
+        /// <value>True if the user could be locked out, otherwise false.</value>
         public virtual bool LockoutEnabled { get; set; }
 
         /// <summary>


### PR DESCRIPTION
According to the logic of method **IsLockedOutAsync** from **UserManager**, **LockoutEnabled** property shows that the user is not locked out or not, it indicates that the user could be locked out, so the description was changed to reflect the actual behavior.