### PR TITLE
Remove Microsoft.AspNet.DataProtection.Extensions

### DIFF
--- a/src/Microsoft.AspNet.Identity.AspNetCoreCompat/project.json
+++ b/src/Microsoft.AspNet.Identity.AspNetCoreCompat/project.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "Microsoft.AspNet.Identity.EntityFramework": "2.2.1",
-    "Microsoft.AspNet.DataProtection.Extensions": "1.0.0-rc1-final",
     "Microsoft.Owin.Security.Cookies": "3.0.1",
     "Microsoft.Owin.Security.Interop": "1.0.0"
   },


### PR DESCRIPTION
cc @HaoK  \ @divega 

Removing this makes patching our repos a bit easy. Since this package didn't ship with RTM, it seemed like an easier fix.