### PR TITLE
remove About and Contact links from the sample

### DIFF
--- a/samples/IdentitySample.Mvc/Controllers/HomeController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/HomeController.cs
@@ -9,21 +9,5 @@ namespace IdentitySample.Controllers
         {
             return View();
         }
-
-        [HttpGet]
-        public IActionResult About()
-        {
-            ViewBag.Message = "Your app description page.";
-
-            return View();
-        }
-
-        [HttpGet]
-        public IActionResult Contact()
-        {
-            ViewBag.Message = "Your contact page.";
-
-            return View();
-        }
     }
 }

--- a/samples/IdentitySample.Mvc/Views/Shared/_Layout.cshtml
+++ b/samples/IdentitySample.Mvc/Views/Shared/_Layout.cshtml
@@ -22,8 +22,6 @@
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">
                         <li><a asp-controller="Home" asp-action="Index">Home</a></li>
-                        <li><a asp-controller="Home" asp-action="About">About</a></li>
-                        <li><a asp-controller="Home" asp-action="Contact">Contact</a></li>
                     </ul>
                     @await Html.PartialAsync("_LoginPartial")
                 </div>


### PR DESCRIPTION
Their corresponding views are missing and when clicked, it gives 404. Not sure if removing is OK (seems so).
