### PR TITLE
Add OnSecurityStampReplacePrincipal event

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
@@ -79,6 +79,6 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Invoked when the default security stamp validator replaces the user's ClaimsPrincipal in the cookie.
         /// </summary>
-        public Func<SecurityStampReplacingPrincipalContext, Task> OnSecurityStampReplacingPrincipal { get; set; }
+        public Func<SecurityStampRefreshingPrincipalContext, Task> OnSecurityStampReplacingPrincipal { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 
 namespace Microsoft.AspNetCore.Builder
@@ -74,5 +75,10 @@ namespace Microsoft.AspNetCore.Builder
         /// The <see cref="TimeSpan"/> after which security stamps are re-validated.
         /// </value>
         public TimeSpan SecurityStampValidationInterval { get; set; } = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Invoked when the default security stamp validator replaces the user's ClaimsPrincipal in the cookie.
+        /// </summary>
+        public Func<SecurityStampReplacingPrincipalContext, Task> OnSecurityStampReplacingPrincipal { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityOptions.cs
@@ -79,6 +79,6 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Invoked when the default security stamp validator replaces the user's ClaimsPrincipal in the cookie.
         /// </summary>
-        public Func<SecurityStampRefreshingPrincipalContext, Task> OnSecurityStampReplacingPrincipal { get; set; }
+        public Func<SecurityStampRefreshingPrincipalContext, Task> OnSecurityStampRefreshingPrincipal { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampRefreshingPrincipalContext.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampRefreshingPrincipalContext.cs
@@ -8,16 +8,16 @@ namespace Microsoft.AspNetCore.Identity
     /// <summary>
     /// Used to pass information during the SecurityStamp validation event.
     /// </summary>
-    public class SecurityStampReplacingPrincipalContext
+    public class SecurityStampRefreshingPrincipalContext
     {
         /// <summary>
         /// The principal contained in the current cookie.
         /// </summary>
-        public ClaimsPrincipal Current { get; set; }
+        public ClaimsPrincipal CurrentPrincipal { get; set; }
 
         /// <summary>
         /// The new principal which should replace the current.
         /// </summary>
-        public ClaimsPrincipal Replacement { get; set; }
+        public ClaimsPrincipal NewPrincipal { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampReplacingPrincipalContext.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampReplacingPrincipalContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    /// <summary>
+    /// Used to pass information during the SecurityStamp validation event.
+    /// </summary>
+    public class SecurityStampReplacingPrincipalContext
+    {
+        /// <summary>
+        /// The principal contained in the current cookie.
+        /// </summary>
+        public ClaimsPrincipal Current { get; set; }
+
+        /// <summary>
+        /// The new principal which should replace the current.
+        /// </summary>
+        public ClaimsPrincipal Replacement { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
@@ -70,15 +70,15 @@ namespace Microsoft.AspNetCore.Identity
 
                     if (_options.OnSecurityStampReplacingPrincipal != null)
                     {
-                        var replaceContext = new SecurityStampReplacingPrincipalContext
+                        var replaceContext = new SecurityStampRefreshingPrincipalContext
                         {
-                            Current = context.Principal,
-                            Replacement = newPrincipal
+                            CurrentPrincipal = context.Principal,
+                            NewPrincipal = newPrincipal
                         };
 
                         // Note: a null principal is allowed and results in a failed authentication.
                         await _options.OnSecurityStampReplacingPrincipal(replaceContext);
-                        newPrincipal = replaceContext.Replacement;
+                        newPrincipal = replaceContext.NewPrincipal;
                     }
 
                     // REVIEW: note we lost login authentication method

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampValidator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Identity
                 {
                     var newPrincipal = await _signInManager.CreateUserPrincipalAsync(user);
 
-                    if (_options.OnSecurityStampReplacingPrincipal != null)
+                    if (_options.OnSecurityStampRefreshingPrincipal != null)
                     {
                         var replaceContext = new SecurityStampRefreshingPrincipalContext
                         {
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Identity
                         };
 
                         // Note: a null principal is allowed and results in a failed authentication.
-                        await _options.OnSecurityStampReplacingPrincipal(replaceContext);
+                        await _options.OnSecurityStampRefreshingPrincipal(replaceContext);
                         newPrincipal = replaceContext.NewPrincipal;
                     }
 

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Identity.InMemory
             var server = CreateServer(services => services.Configure<IdentityOptions>(options =>
             {
                 options.Cookies.ApplicationCookie.SystemClock = clock;
-                options.OnSecurityStampReplacingPrincipal = c =>
+                options.OnSecurityStampRefreshingPrincipal = c =>
                 {
                     var newId = new ClaimsIdentity();
                     newId.AddClaim(new Claim("PreviousName", c.CurrentPrincipal.Identity.Name));

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
@@ -140,6 +140,54 @@ namespace Microsoft.AspNetCore.Identity.InMemory
         }
 
         [Fact]
+        public async Task CanAccessOldPrincipalDuringSecurityStampReplacement()
+        {
+            var clock = new TestClock();
+            var server = CreateServer(services => services.Configure<IdentityOptions>(options =>
+            {
+                options.Cookies.ApplicationCookie.SystemClock = clock;
+                options.OnSecurityStampReplacingPrincipal = c =>
+                {
+                    var newId = new ClaimsIdentity();
+                    newId.AddClaim(new Claim("PreviousName", c.Current.Identity.Name));
+                    c.Replacement.AddIdentity(newId);
+                    return Task.FromResult(0);
+                };
+            }));
+
+            var transaction1 = await SendAsync(server, "http://example.com/createMe");
+            Assert.Equal(HttpStatusCode.OK, transaction1.Response.StatusCode);
+            Assert.Null(transaction1.SetCookie);
+
+            var transaction2 = await SendAsync(server, "http://example.com/pwdLogin/false" );
+            Assert.Equal(HttpStatusCode.OK, transaction2.Response.StatusCode);
+            Assert.NotNull(transaction2.SetCookie);
+            Assert.DoesNotContain("; expires=", transaction2.SetCookie);
+
+            var transaction3 = await SendAsync(server, "http://example.com/me", transaction2.CookieNameValue);
+            Assert.Equal("hao", FindClaimValue(transaction3, ClaimTypes.Name));
+            Assert.Null(transaction3.SetCookie);
+
+            // Make sure we don't get a new cookie yet
+            clock.Add(TimeSpan.FromMinutes(10));
+            var transaction4 = await SendAsync(server, "http://example.com/me", transaction2.CookieNameValue);
+            Assert.Equal("hao", FindClaimValue(transaction4, ClaimTypes.Name));
+            Assert.Null(transaction4.SetCookie);
+
+            // Go past SecurityStampValidation interval and ensure we get a new cookie
+            clock.Add(TimeSpan.FromMinutes(21));
+
+            var transaction5 = await SendAsync(server, "http://example.com/me", transaction2.CookieNameValue);
+            Assert.NotNull(transaction5.SetCookie);
+            Assert.Equal("hao", FindClaimValue(transaction5, ClaimTypes.Name));
+            Assert.Equal("hao", FindClaimValue(transaction5, "PreviousName"));
+
+            // Make sure new cookie is valid
+            var transaction6 = await SendAsync(server, "http://example.com/me", transaction5.CookieNameValue);
+            Assert.Equal("hao", FindClaimValue(transaction6, ClaimTypes.Name));
+        }
+
+        [Fact]
         public async Task TwoFactorRememberCookieVerification()
         {
             var server = CreateServer();

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
@@ -149,8 +149,8 @@ namespace Microsoft.AspNetCore.Identity.InMemory
                 options.OnSecurityStampReplacingPrincipal = c =>
                 {
                     var newId = new ClaimsIdentity();
-                    newId.AddClaim(new Claim("PreviousName", c.Current.Identity.Name));
-                    c.Replacement.AddIdentity(newId);
+                    newId.AddClaim(new Claim("PreviousName", c.CurrentPrincipal.Identity.Name));
+                    c.NewPrincipal.AddIdentity(newId);
                     return Task.FromResult(0);
                 };
             }));


### PR DESCRIPTION
Fixes https://github.com/aspnet/Identity/issues/958

Adds a new event called from the default security stamp validator which allows tweaking the user principal regeneration using the old principal.

Not super happy with the name (or the fact that the event lives at the top level of IdentityOptions)

cc @divega @blowdart 