### PR TITLE
Removed duplicate call to IsLockedOut()

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -301,10 +301,6 @@ namespace Microsoft.AspNetCore.Identity
                 return error;
             }
 
-            if (await IsLockedOut(user))
-            {
-                return await LockedOut(user);
-            }
             if (await UserManager.CheckPasswordAsync(user, password))
             {
                 await ResetLockout(user);


### PR DESCRIPTION
There's no need to call IsLockedOut() anymore as this is already done in PreSignInCheck().