### PR TITLE
User online control

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityDbContext.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityDbContext.cs
@@ -152,6 +152,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
                 b.HasKey(u => u.Id);
                 b.HasIndex(u => u.NormalizedUserName).HasName("UserNameIndex").IsUnique();
                 b.HasIndex(u => u.NormalizedEmail).HasName("EmailIndex");
+                b.HasIndex(u => u.LastActivity).HasName("ActivityIndex");
                 b.ToTable("AspNetUsers");
                 b.Property(u => u.ConcurrencyStamp).IsConcurrencyToken();
 

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityUser.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityUser.cs
@@ -137,6 +137,15 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         /// </remarks>
         public virtual DateTimeOffset? LockoutEnd { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets the date and time, in UTC, when last user's activity was registered
+        /// </summary>
+        /// <remarks>
+        /// Null value means that user signed off manually (or never signed in)
+        /// </remarks>
+        public virtual DateTimeOffset? LastActivity { get; set; }
+
         /// <summary>
         /// Gets or sets a flag indicating if the user could be locked out.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
@@ -1456,6 +1456,10 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
+            if (activitySpan > TimeSpan.FromDays(10000))
+            {
+                activitySpan = TimeSpan.FromDays(10000);
+            }
             var margin = DateTimeOffset.UtcNow - activitySpan;
             var query = Users.Where(u => u.LastActivity.HasValue && u.LastActivity.Value > margin);
             return Task.FromResult(query);
@@ -1522,8 +1526,30 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
             {
                 throw new ArgumentNullException(nameof(user));
             }
+            if (activitySpan > TimeSpan.FromDays(10000))
+            {
+                activitySpan = TimeSpan.FromDays(10000);
+            }
             var margin = DateTimeOffset.UtcNow - activitySpan;
             return await Task.FromResult(user.LastActivity.HasValue && user.LastActivity.Value > margin);
+        }
+
+        /// <summary>
+        /// Gets activity timestamp of the specified user
+        /// </summary>
+        /// <param name="user">The user, whose activity timestamp is being retrived</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>Activity timestamp of the specified user</returns>
+        public Task<DateTimeOffset?> GetUserActivityTimestampAsync(TUser user, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            
+            return Task.FromResult(user.LastActivity);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
@@ -1452,7 +1452,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         /// <param name="activitySpan">Time span for activity</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a list of online users</returns>
-        public Task<IQueryable<TUser>> GetOnlineUsers(TimeSpan activitySpan, CancellationToken cancellationToken)
+        public Task<IQueryable<TUser>> GetOnlineUsersAsync(TimeSpan activitySpan, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
@@ -201,7 +201,8 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         IUserPhoneNumberStore<TUser>,
         IQueryableUserStore<TUser>,
         IUserTwoFactorStore<TUser>,
-        IUserAuthenticationTokenStore<TUser>
+        IUserAuthenticationTokenStore<TUser>,
+        IUserActivityStore<TUser>
         where TUser : IdentityUser<TKey, TUserClaim, TUserRole, TUserLogin>
         where TRole : IdentityRole<TKey, TUserRole, TRoleClaim>
         where TContext : DbContext
@@ -1442,6 +1443,87 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
             }
             var entry = await FindToken(user, loginProvider, name, cancellationToken);
             return entry?.Value;
+        }
+
+
+        /// <summary>
+        /// Provides list of users that has registered activity in specified time span
+        /// </summary>
+        /// <param name="activitySpan">Time span for activity</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a list of online users</returns>
+        public Task<IQueryable<TUser>> GetOnlineUsers(TimeSpan activitySpan, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            var margin = DateTimeOffset.UtcNow - activitySpan;
+            var query = Users.Where(u => u.LastActivity.HasValue && u.LastActivity.Value > margin);
+            return Task.FromResult(query);
+        }
+
+       
+        /// <summary>
+        /// Sets user's last activity timestamp
+        /// </summary>
+        /// <param name="user">The user, whose activity is being updated</param>
+        /// <param name="activityTime">Timestamp of last registered activity (null for reset)</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        protected virtual Task SetActivityTimeAsync(TUser user, DateTimeOffset? activityTime,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            user.LastActivity = activityTime;
+            return TaskCache.CompletedTask;
+        }
+
+        /// <summary>
+        /// Updates user's last activity timestamp
+        /// </summary>
+        /// <param name="user">The user, whose activity is being updated</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task UpdateActivityTimeAsync(TUser user, CancellationToken cancellationToken)
+        {
+            await SetActivityTimeAsync(user, DateTimeOffset.UtcNow, cancellationToken);
+        }
+
+        /// <summary>
+        /// Resets user's last activity timestamp
+        /// </summary>
+        /// <param name="user">The user, whose activity is being reset</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task ResetActivityTimeAsync(TUser user, CancellationToken cancellationToken)
+        {
+            await SetActivityTimeAsync(user, null, cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Checks if user has registered activity in specified time span
+        /// </summary>
+        /// <param name="user">The user, whose activity is being checked</param>
+        /// <param name="activitySpan">Time span for checking activity</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a flag indicating user's activity</returns>
+        public async Task<bool> IsUserActiveAsync(TUser user, TimeSpan activitySpan, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            var margin = DateTimeOffset.UtcNow - activitySpan;
+            return await Task.FromResult(user.LastActivity.HasValue && user.LastActivity.Value > margin);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
+++ b/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,39 +15,38 @@ namespace Microsoft.AspNetCore.Identity
     {
 
         /// <summary>
-        /// Provides list of users that has shown activity during specified time span
+        /// Provides list of users that has registered activity in specified time span
         /// </summary>
-        /// <param name="idleTimeout"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns>List of online users</returns>
-        /// 
-        Task<IList<TUser>> GetOnlineUsers(TimeSpan idleTimeout, CancellationToken cancellationToken);
+        /// <param name="activitySpan">Time span for activity</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a list of online users</returns>
+        Task<IQueryable<TUser>> GetOnlineUsers(TimeSpan activitySpan, CancellationToken cancellationToken);
 
         /// <summary>
-        /// 
+        /// Updates user's last activity timestamp
         /// </summary>
-        /// <param name="user"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<IdentityResult> UpdateActivityTimeAsync(TUser user, CancellationToken cancellationToken);
-
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="user"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<IdentityResult> ResetActivityTimeAsync(TUser user, CancellationToken cancellationToken);
+        /// <param name="user">The user, whose activity is being updated</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task UpdateActivityTimeAsync(TUser user, CancellationToken cancellationToken);
 
 
         /// <summary>
-        /// 
+        /// Resets user's last activity timestamp
         /// </summary>
-        /// <param name="user"></param>
-        /// <param name="activitySpan"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="user">The user, whose activity is being reset</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task ResetActivityTimeAsync(TUser user, CancellationToken cancellationToken);
+
+
+        /// <summary>
+        /// Checks if user has registered activity in specified time span
+        /// </summary>
+        /// <param name="user">The user, whose activity is being checked</param>
+        /// <param name="activitySpan">Time span for checking activity</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a flag indicating user's activity</returns>
         Task<bool> IsUserActiveAsync(TUser user, TimeSpan activitySpan, CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
+++ b/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
@@ -50,5 +50,14 @@ namespace Microsoft.AspNetCore.Identity
         Task<bool> IsUserActiveAsync(TUser user, TimeSpan activitySpan, CancellationToken cancellationToken);
 
 
+        /// <summary>
+        /// Gets activity timestamp of the specified user
+        /// </summary>
+        /// <param name="user">The user, whose activity timestamp is being retrived</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>Activity timestamp of the specified user</returns>
+        Task<DateTimeOffset?> GetUserActivityTimestampAsync(TUser user, CancellationToken cancellationToken);
+
+
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
+++ b/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <param name="activitySpan">Time span for activity</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a list of online users</returns>
-        Task<IQueryable<TUser>> GetOnlineUsers(TimeSpan activitySpan, CancellationToken cancellationToken);
+        Task<IQueryable<TUser>> GetOnlineUsersAsync(TimeSpan activitySpan, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates user's last activity timestamp

--- a/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
+++ b/src/Microsoft.AspNetCore.Identity/IUserActivityStore.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    /// <summary>
+    /// Provides an abstraction for a storing information which can be used to determine
+    /// which users are online.
+    /// </summary>
+    /// <typeparam name="TUser">The type that represents a user.</typeparam>
+    public interface IUserActivityStore<TUser> : IUserStore<TUser> where TUser : class
+    {
+
+        /// <summary>
+        /// Provides list of users that has shown activity during specified time span
+        /// </summary>
+        /// <param name="idleTimeout"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>List of online users</returns>
+        /// 
+        Task<IList<TUser>> GetOnlineUsers(TimeSpan idleTimeout, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IdentityResult> UpdateActivityTimeAsync(TUser user, CancellationToken cancellationToken);
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IdentityResult> ResetActivityTimeAsync(TUser user, CancellationToken cancellationToken);
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="activitySpan"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<bool> IsUserActiveAsync(TUser user, TimeSpan activitySpan, CancellationToken cancellationToken);
+
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Identity/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Identity/Properties/Resources.Designer.cs
@@ -539,6 +539,22 @@ namespace Microsoft.AspNetCore.Identity
         }
 
         /// <summary>
+        /// Store does not implement IUserActivityStore&lt;TUser&gt;.
+        /// </summary>
+        internal static string StoreNotIUserActivityStore
+        {
+            get { return GetString("StoreNotIUserActivityStore"); }
+        }
+
+        /// <summary>
+        /// Store does not implement IUserActivityStore&lt;TUser&gt;.
+        /// </summary>
+        internal static string FormatStoreNotIUserActivityStore()
+        {
+            return GetString("StoreNotIUserActivityStore");
+        }
+
+        /// <summary>
         /// Store does not implement IUserSecurityStampStore&lt;TUser&gt;.
         /// </summary>
         internal static string StoreNotIUserSecurityStampStore

--- a/src/Microsoft.AspNetCore.Identity/Resources.resx
+++ b/src/Microsoft.AspNetCore.Identity/Resources.resx
@@ -213,6 +213,10 @@
     <value>Store does not implement IQueryableUserStore&lt;TUser&gt;.</value>
     <comment>Error when the store does not implement this interface</comment>
   </data>
+  <data name="StoreNotIUserActivityStore" xml:space="preserve">
+    <value>Store does not implement IUserActivityStore&lt;TUser&gt;.</value>
+    <comment>Error when the store does not implement this interface</comment>
+  </data>
   <data name="StoreNotIRoleClaimStore" xml:space="preserve">
     <value>Store does not implement IRoleClaimStore&lt;TRole&gt;.</value>
     <comment>Error when the store does not implement this interface</comment>

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -698,7 +698,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             if (Options.User.MaximumSignedIn > 0 && UserManager.SupportsUserActivity)
             {
-                var usersCount = (await UserManager.GetActiveUsers()).Count();
+                var usersCount = (await UserManager.GetActiveUsersAsync()).Count();
                 if (usersCount >= Options.User.MaximumSignedIn)
                 {
                     return SignInResult.SignedIn;

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -199,7 +199,11 @@ namespace Microsoft.AspNetCore.Identity
 
             if (UserManager.SupportsUserActivity)
             {
-                await UserManager.SetUserActiveAsync(user, true);
+                await UserManager.SetUserActiveAsync(user);
+                if (Options.User.MaximumSignedIn > 0)
+                {
+                    await UserManager.EnsureMaximumOnlineAsync();
+                }
             }            
 
             await Context.Authentication.SignInAsync(Options.Cookies.ApplicationCookieAuthenticationScheme,

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>The task object representing the asynchronous operation.</returns>
         public virtual async Task SignInAsync(TUser user, AuthenticationProperties authenticationProperties, string authenticationMethod = null)
         {
-            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserSecurityStamp)
+            if (Options.User.DisableMultipleLogin && UserManager.SupportsUserSecurityStamp)
             {
                 await UserManager.UpdateSecurityStampAsync(user);
             }
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Identity
         /// </summary>
         public virtual async Task SignOutAsync()
         {
-            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserActivity)
+            if (Options.User.DisableMultipleLogin && UserManager.SupportsUserActivity)
             {
                 var user = await UserManager.GetUserAsync(Context.User);
                 await UserManager.SetUserActiveAsync(user, false);
@@ -685,9 +685,17 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>Null if the user should be allowed to sign in, otherwise the SignInResult why they should be denied.</returns>
         protected virtual async Task<SignInResult> PreSignInCheck(TUser user)
         {
-            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserActivity)
+            if (Options.User.DisableMultipleLogin && UserManager.SupportsUserActivity)
             {
                 if (await UserManager.IsUserActiveAsync(user))
+                {
+                    return SignInResult.SignedIn;
+                }
+            }
+            if (Options.User.MaximumSignedIn > 0 && UserManager.SupportsUserActivity)
+            {
+                var usersCount = (await UserManager.GetActiveUsers()).Count();
+                if (usersCount >= Options.User.MaximumSignedIn)
                 {
                     return SignInResult.SignedIn;
                 }

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -186,12 +186,22 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>The task object representing the asynchronous operation.</returns>
         public virtual async Task SignInAsync(TUser user, AuthenticationProperties authenticationProperties, string authenticationMethod = null)
         {
+            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserSecurityStamp)
+            {
+                await UserManager.UpdateSecurityStampAsync(user);
+            }
             var userPrincipal = await CreateUserPrincipalAsync(user);
             // Review: should we guard against CreateUserPrincipal returning null?
             if (authenticationMethod != null)
             {
                 userPrincipal.Identities.First().AddClaim(new Claim(ClaimTypes.AuthenticationMethod, authenticationMethod));
             }
+
+            if (UserManager.SupportsUserActivity)
+            {
+                await UserManager.SetUserActiveAsync(user, true);
+            }            
+
             await Context.Authentication.SignInAsync(Options.Cookies.ApplicationCookieAuthenticationScheme,
                 userPrincipal,
                 authenticationProperties ?? new AuthenticationProperties());
@@ -202,6 +212,11 @@ namespace Microsoft.AspNetCore.Identity
         /// </summary>
         public virtual async Task SignOutAsync()
         {
+            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserActivity)
+            {
+                var user = await UserManager.GetUserAsync(Context.User);
+                await UserManager.SetUserActiveAsync(user, false);
+            }
             await Context.Authentication.SignOutAsync(Options.Cookies.ApplicationCookieAuthenticationScheme);
             await Context.Authentication.SignOutAsync(Options.Cookies.ExternalCookieAuthenticationScheme);
             await Context.Authentication.SignOutAsync(Options.Cookies.TwoFactorUserIdCookieAuthenticationScheme);
@@ -670,6 +685,13 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>Null if the user should be allowed to sign in, otherwise the SignInResult why they should be denied.</returns>
         protected virtual async Task<SignInResult> PreSignInCheck(TUser user)
         {
+            if (Options.User.RestrictMultipleLogin && UserManager.SupportsUserActivity)
+            {
+                if (await UserManager.IsUserActiveAsync(user))
+                {
+                    return SignInResult.SignedIn;
+                }
+            }
             if (!await CanSignInAsync(user))
             {
                 return SignInResult.NotAllowed;

--- a/src/Microsoft.AspNetCore.Identity/SignInResult.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInResult.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Identity
         private static readonly SignInResult _lockedOut = new SignInResult { IsLockedOut = true };
         private static readonly SignInResult _notAllowed = new SignInResult { IsNotAllowed = true };
         private static readonly SignInResult _twoFactorRequired = new SignInResult { RequiresTwoFactor = true };
+        private static readonly SignInResult _alreadySignedIn = new SignInResult {AlreadySignedIn = true};
 
         /// <summary>
         /// Returns a flag indication whether the sign-in was successful.
@@ -39,6 +40,12 @@ namespace Microsoft.AspNetCore.Identity
         /// </summary>
         /// <value>True if the user attempting to sign-in requires two factor authentication, otherwise false.</value>
         public bool RequiresTwoFactor { get; protected set; }
+
+        /// <summary>
+        /// Returns a flag indication whether the user attempting to sign-in is already signed in.
+        /// </summary>
+        /// <value>True if user attempting so sign-is is already signed in and multiple sign in is not allowed</value>
+        public bool AlreadySignedIn { get; protected set; }
 
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a successful sign-in.
@@ -76,6 +83,15 @@ namespace Microsoft.AspNetCore.Identity
         /// authentication.</returns>
         public static SignInResult TwoFactorRequired => _twoFactorRequired;
 
+
+        /// <summary>
+        /// Returns a <see cref="SignInResult"/> that represents a sign-in attempt from a user
+        /// which is already signed in when multiple sign-in is not allowed.
+        /// </summary>
+        /// <returns>Returns a &lt;see cref="SignInResult"/&gt; that represents a sign-in attempt from a user
+        ///  which is already signed in when multiple sign-in is not allowed.</returns>
+        public static SignInResult SignedIn => _alreadySignedIn;
+
         /// <summary>
         /// Converts the value of the current <see cref="SignInResult"/> object to its equivalent string representation.
         /// </summary>
@@ -85,7 +101,8 @@ namespace Microsoft.AspNetCore.Identity
             return IsLockedOut ? "Lockedout" : 
 		   	       IsNotAllowed ? "NotAllowed" : 
 			       RequiresTwoFactor ? "RequiresTwoFactor" : 
-			       Succeeded ? "Succeeded" : "Failed";
+			       Succeeded ? "Succeeded" :
+                   AlreadySignedIn ? "SignedIn" : "Failed";
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -1479,7 +1479,20 @@ namespace Microsoft.AspNetCore.Identity
                 throw new ArgumentNullException(nameof(user));
             }
             
-            return await store.IsUserActiveAsync(user, Options.User.MultipleLoginTimeout, CancellationToken);
+            return await store.IsUserActiveAsync(user, Options.User.ActivityTimeout, CancellationToken);
+        }
+
+
+        /// <summary>
+        /// Returns an <see cref="IQueryable{T}"/> collection of currently active users
+        /// </summary>
+        /// <returns>An <see cref="IQueryable{T}"/> collection of currently active users</returns>
+        public virtual async Task<IQueryable<TUser>> GetActiveUsers()
+        {
+            ThrowIfDisposed();
+            var store = GetActivityStore();
+
+            return await store.GetOnlineUsers(Options.User.ActivityTimeout, CancellationToken);
         }
 
 

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -1492,7 +1492,7 @@ namespace Microsoft.AspNetCore.Identity
             ThrowIfDisposed();
             var store = GetActivityStore();
 
-            return await store.GetOnlineUsers(Options.User.ActivityTimeout, CancellationToken);
+            return await store.GetOnlineUsersAsync(Options.User.ActivityTimeout, CancellationToken);
         }
 
         /// <summary>
@@ -1510,13 +1510,13 @@ namespace Microsoft.AspNetCore.Identity
                 return;
             }
 
-            var everActiveCount = (await store.GetOnlineUsers(TimeSpan.MaxValue, CancellationToken)).Count();
+            var everActiveCount = (await store.GetOnlineUsersAsync(TimeSpan.MaxValue, CancellationToken)).Count();
             if (everActiveCount <= Options.User.MaximumSignedIn)
             {
                 return;
             }
 
-            var userTaskList = (await store.GetOnlineUsers(TimeSpan.MaxValue, CancellationToken))
+            var userTaskList = (await store.GetOnlineUsersAsync(TimeSpan.MaxValue, CancellationToken))
                             .Select(u => new { User = u, ActivityTask = store.GetUserActivityTimestampAsync(u, CancellationToken) })
                             .ToList();
             await Task.WhenAll(userTaskList.Select(x => x.ActivityTask));

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -1487,7 +1487,7 @@ namespace Microsoft.AspNetCore.Identity
         /// Returns an <see cref="IQueryable{T}"/> collection of currently active users
         /// </summary>
         /// <returns>An <see cref="IQueryable{T}"/> collection of currently active users</returns>
-        public virtual async Task<IQueryable<TUser>> GetActiveUsers()
+        public virtual async Task<IQueryable<TUser>> GetActiveUsersAsync()
         {
             ThrowIfDisposed();
             var store = GetActivityStore();

--- a/src/Microsoft.AspNetCore.Identity/UserOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserOptions.cs
@@ -31,17 +31,27 @@ namespace Microsoft.AspNetCore.Identity
         /// with different devices/browsers.
         /// </summary>
         /// <value>
-        /// True if the application requires user sign out before signing in again, otherwise false.
+        /// True if the application requires user sign out before signing in again from another place, otherwise false.
         /// </value>
-        public bool RestrictMultipleLogin { get; set; } = false;
+        public bool DisableMultipleLogin { get; set; } = false;
 
 
         /// <summary>
-        /// Gets or sets time before idle user is considered signed out.
+        /// Gets or sets time before user is considered idle
         /// </summary>
         /// <value>
-        /// Time before idle user is considered signed out.
+        /// Time before user is considered idle
         /// </value>
-        public TimeSpan MultipleLoginTimeout { get; set; } = TimeSpan.FromMinutes(30);
+        public TimeSpan ActivityTimeout { get; set; } = TimeSpan.FromMinutes(30);
+
+
+        /// <summary>
+        /// Gets or sets limit for maximum concurrent signed in users
+        /// </summary>
+        /// <value>
+        /// Maximum limit of signed in active users (0 for unlimited)
+        /// </value>
+        public int MaximumSignedIn { get; set; } = 0;
+
     }
 }

--- a/src/Microsoft.AspNetCore.Identity/UserOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserOptions.cs
@@ -37,10 +37,11 @@ namespace Microsoft.AspNetCore.Identity
 
 
         /// <summary>
-        /// Gets or sets time before user is considered idle
+        /// Gets or sets time before user is considered idle. If MaximumSignedIn is set to positive
+        /// value, idle users can be signed off forcefully when new users sign in.
         /// </summary>
         /// <value>
-        /// Time before user is considered idle
+        /// Time before user is considered idle. 
         /// </value>
         public TimeSpan ActivityTimeout { get; set; } = TimeSpan.FromMinutes(30);
 

--- a/src/Microsoft.AspNetCore.Identity/UserOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Identity
 {
     /// <summary>
@@ -23,5 +25,23 @@ namespace Microsoft.AspNetCore.Identity
         /// True if the application requires each user to have their own, unique email, otherwise false.
         /// </value>
         public bool RequireUniqueEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating whether the users are allowed to sign in simultaneously
+        /// with different devices/browsers.
+        /// </summary>
+        /// <value>
+        /// True if the application requires user sign out before signing in again, otherwise false.
+        /// </value>
+        public bool RestrictMultipleLogin { get; set; } = false;
+
+
+        /// <summary>
+        /// Gets or sets time before idle user is considered signed out.
+        /// </summary>
+        /// <value>
+        /// Time before idle user is considered signed out.
+        /// </value>
+        public TimeSpan MultipleLoginTimeout { get; set; } = TimeSpan.FromMinutes(30);
     }
 }

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/SqlStoreTestBase.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/SqlStoreTestBase.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
                 db.Open();
                 Assert.True(VerifyColumns(db, "AspNetUsers", "Id", "UserName", "Email", "PasswordHash", "SecurityStamp",
                     "EmailConfirmed", "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled",
-                    "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail"));
+                    "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail", "LastActivity"));
                 Assert.True(VerifyColumns(db, "AspNetRoles", "Id", "Name", "NormalizedName", "ConcurrencyStamp"));
                 Assert.True(VerifyColumns(db, "AspNetUserRoles", "UserId", "RoleId"));
                 Assert.True(VerifyColumns(db, "AspNetUserClaims", "Id", "UserId", "ClaimType", "ClaimValue"));
@@ -119,6 +119,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
                 VerifyIndex(db, "AspNetRoles", "RoleNameIndex", isUnique: true);
                 VerifyIndex(db, "AspNetUsers", "UserNameIndex", isUnique: true);
                 VerifyIndex(db, "AspNetUsers", "EmailIndex");
+                VerifyIndex(db, "AspNetUsers", "ActivityIndex");
                 db.Close();
             }
         }


### PR DESCRIPTION
The application we are developing requires disabling users to log in simultaneously from different browsers and also restricting maximum number of signed in users.

Firstly i've implemented that functionality on top of Identity and then i thought it could be used by someone else.

Changes:
Added LastActivity timestamp field to `IdentityUser`
Added `IUserActivityStore` interface to query active users
Added checks in `CanSignInAsync` method 
Added automatic forced signing off of idle users if maximum online is reached

Addresses #1019