### PR TITLE
Making UpdatePasswordHash protected and accessible to descendants

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -2160,7 +2160,7 @@ namespace Microsoft.AspNetCore.Identity
             }
         }
 
-        internal async Task<IdentityResult> UpdatePasswordHash(IUserPasswordStore<TUser> passwordStore,
+        protected internal async Task<IdentityResult> UpdatePasswordHash(IUserPasswordStore<TUser> passwordStore,
             TUser user, string newPassword, bool validatePassword = true)
         {
             if (validatePassword)

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -2160,6 +2160,17 @@ namespace Microsoft.AspNetCore.Identity
             }
         }
 
+        /// <summary>
+        /// Updates password hash of the specified user
+        /// </summary>
+        /// <param name="passwordStore">Implementation of the password store to be used </param>
+        /// <param name="user">User whose password hash should be updated</param>
+        /// <param name="newPassword">Plain text password which will be hashed and assignd to user</param>
+        /// <param name="validatePassword">Flag indicating that new password shoud be validated</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
         protected internal async Task<IdentityResult> UpdatePasswordHash(IUserPasswordStore<TUser> passwordStore,
             TUser user, string newPassword, bool validatePassword = true)
         {


### PR DESCRIPTION
Currently `UpdatePasswordHash` is private. This makes everyone who wants to override virtual methods (i.e. `AddPasswordAsync`, `ChangePasswordAsync` etc) or implement other password-related method (i.e. administrative password-change for the user) to copy-paste all the code related to validating and hashing passwords. 

Making this method protected and therefore accessible to descendant classes will make it a bit easier. 

Edit: Addresses #1029