### PR TITLE
In sample use FindByEmailAsync in ResetPassword flow

### DIFF
--- a/samples/IdentitySample.Mvc/Controllers/AccountController.cs
+++ b/samples/IdentitySample.Mvc/Controllers/AccountController.cs
@@ -270,7 +270,7 @@ namespace IdentitySample.Controllers
         {
             if (ModelState.IsValid)
             {
-                var user = await _userManager.FindByNameAsync(model.Email);
+                var user = await _userManager.FindByEmailAsync(model.Email);
                 if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
                 {
                     // Don't reveal that the user does not exist or is not confirmed
@@ -319,7 +319,7 @@ namespace IdentitySample.Controllers
             {
                 return View(model);
             }
-            var user = await _userManager.FindByNameAsync(model.Email);
+            var user = await _userManager.FindByEmailAsync(model.Email);
             if (user == null)
             {
                 // Don't reveal that the user does not exist


### PR DESCRIPTION
Since the password reset flow is asking for an email, use `FindByEmailAsync` instead of `FindByNameAsync` in case the developer has decoupled the two fields to use usernames.