### PR TITLE
Expose options/other services on managers

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/RoleManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/RoleManager.cs
@@ -69,13 +69,13 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The <see cref="ILogger"/> used to log messages from the manager.
         /// </value>
-        protected internal virtual ILogger Logger { get; set; }
+        public virtual ILogger Logger { get; set; }
 
         /// <summary>
         /// Gets a list of validators for roles to call before persistence.
         /// </summary>
         /// <value>A list of validators for roles to call before persistence.</value>
-        internal IList<IRoleValidator<TRole>> RoleValidators { get; } = new List<IRoleValidator<TRole>>();
+        public IList<IRoleValidator<TRole>> RoleValidators { get; } = new List<IRoleValidator<TRole>>();
 
         /// <summary>
         /// Gets the <see cref="IdentityErrorDescriber"/> used to provider error messages.
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The <see cref="IdentityErrorDescriber"/> used to provider error messages.
         /// </value>
-        internal IdentityErrorDescriber ErrorDescriber { get; set; }
+        public IdentityErrorDescriber ErrorDescriber { get; set; }
 
         /// <summary>
         /// Gets the normalizer to use when normalizing role names to keys.
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The normalizer to use when normalizing role names to keys.
         /// </value>
-        internal ILookupNormalizer KeyNormalizer { get; set; }
+        public ILookupNormalizer KeyNormalizer { get; set; }
 
         /// <summary>
         /// Gets an IQueryable collection of Roles if the persistence store is an <see cref="IQueryableRoleStore{TRole}"/>,

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -71,27 +69,27 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The <see cref="ILogger"/> used to log messages from the manager.
         /// </value>
-        protected internal virtual ILogger Logger { get; set; }
+        public virtual ILogger Logger { get; set; }
 
         /// <summary>
         /// The <see cref="UserManager{TUser}"/> used.
         /// </summary>
-        protected internal UserManager<TUser> UserManager { get; set; }
+        public UserManager<TUser> UserManager { get; set; }
 
         /// <summary>
         /// The <see cref="IUserClaimsPrincipalFactory{TUser}"/> used.
         /// </summary>
-        protected internal IUserClaimsPrincipalFactory<TUser> ClaimsFactory { get; set; }
+        public IUserClaimsPrincipalFactory<TUser> ClaimsFactory { get; set; }
 
         /// <summary>
         /// The <see cref="IdentityOptions"/> used.
         /// </summary>
-        protected internal IdentityOptions Options { get; set; }
+        public IdentityOptions Options { get; set; }
 
         /// <summary>
         /// The <see cref="HttpContext"/> used.
         /// </summary>
-        protected internal HttpContext Context { 
+        public HttpContext Context { 
             get
             {
                 var context = _context ?? _contextAccessor?.HttpContext;

--- a/src/Microsoft.AspNetCore.Identity/UserManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserManager.cs
@@ -122,37 +122,37 @@ namespace Microsoft.AspNetCore.Identity
         /// <value>
         /// The <see cref="ILogger"/> used to log messages from the manager.
         /// </value>
-        protected internal virtual ILogger Logger { get; set; }
+        public virtual ILogger Logger { get; set; }
 
         /// <summary>
         /// The <see cref="IPasswordHasher{TUser}"/> used to hash passwords.
         /// </summary>
-        protected internal IPasswordHasher<TUser> PasswordHasher { get; set; }
+        public IPasswordHasher<TUser> PasswordHasher { get; set; }
 
         /// <summary>
         /// The <see cref="IUserValidator{TUser}"/> used to validate users.
         /// </summary>
-        protected internal IList<IUserValidator<TUser>> UserValidators { get; } = new List<IUserValidator<TUser>>();
+        public IList<IUserValidator<TUser>> UserValidators { get; } = new List<IUserValidator<TUser>>();
 
         /// <summary>
         /// The <see cref="IPasswordValidator{TUser}"/> used to validate passwords.
         /// </summary>
-        protected internal IList<IPasswordValidator<TUser>> PasswordValidators { get; } = new List<IPasswordValidator<TUser>>();
+        public IList<IPasswordValidator<TUser>> PasswordValidators { get; } = new List<IPasswordValidator<TUser>>();
 
         /// <summary>
         /// The <see cref="ILookupNormalizer"/> used to normalize things like user and role names.
         /// </summary>
-        protected internal ILookupNormalizer KeyNormalizer { get; set; }
+        public ILookupNormalizer KeyNormalizer { get; set; }
 
         /// <summary>
         /// The <see cref="IdentityErrorDescriber"/> used to generate error messages.
         /// </summary>
-        protected internal IdentityErrorDescriber ErrorDescriber { get; set; }
+        public IdentityErrorDescriber ErrorDescriber { get; set; }
 
         /// <summary>
         /// The <see cref="IdentityOptions"/> used to configure Identity.
         /// </summary>
-        protected internal IdentityOptions Options { get; set; }
+        public IdentityOptions Options { get; set; }
 
         /// <summary>
         /// Gets a flag indicating whether the backing user store supports authentication tokens.


### PR DESCRIPTION
Fixes https://github.com/aspnet/Identity/issues/1061

To be consistent (and to return to how things were in 2.0) I restored public access to all the dependant services again (which were protected internal) except the Store which we don't want people to use directly

cc @divega @blowdart 