### PR TITLE
React to clock changes

### DIFF
--- a/test/Microsoft.AspNetCore.Identity.Test/SecurityStampValidatorTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/SecurityStampValidatorTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
             var principal = new ClaimsPrincipal(id);
 
-            var properties = new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow, IsPersistent = isPersistent };
+            var properties = new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow.AddSeconds(-1), IsPersistent = isPersistent };
             var signInManager = new Mock<SignInManager<TestUser>>(userManager.Object,
                 contextAccessor.Object, claimsManager.Object, options.Object, null);
             signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user).Verifiable();
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
 
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
-                new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow },
+                new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow.AddSeconds(-1) },
                 identityOptions.Cookies.ApplicationCookieAuthenticationScheme);
             var context = new CookieValidatePrincipalContext(httpContext.Object, ticket, new CookieAuthenticationOptions());
             Assert.NotNull(context.Properties);


### PR DESCRIPTION
Fixes CI failures caused by https://github.com/aspnet/Security/commit/fea5d5cfdc8fc9413ba7816cc108f4d893ac16e1

cc @anurse @Tratcher @divega @blowdart 

Since cookies clock is now seconds granulaurity, maybe we should change the corresponding SecurityStampValidationInterval to be total seconds instead of a Timespan which causes issues now

