### PR TITLE
Allow derived types of UserClaimsPrincipalFactory to return ClaimsPrincipals.

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/UserClaimsPrincipalFactory.cs
+++ b/src/Microsoft.AspNetCore.Identity/UserClaimsPrincipalFactory.cs
@@ -113,7 +113,17 @@ namespace Microsoft.AspNetCore.Identity
             {
                 id.AddClaims(await UserManager.GetClaimsAsync(user));
             }
-            return new ClaimsPrincipal(id);
+            return await CreatePrincipalAsync(id);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ClaimsPrincipal"/> from a <see cref="ClaimsIdentity"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="ClaimsIdentity"/> with claims.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous creation operation, containing the <see cref="ClaimsPrincipal"/> with the <see cref="ClaimsIdentity"/>.</returns>
+        protected virtual Task<ClaimsPrincipal> CreatePrincipalAsync(ClaimsIdentity id)
+        {
+            return Task.FromResult(new ClaimsPrincipal(id));
         }
     }
 }


### PR DESCRIPTION
Fixes #1098. Allows derived types of `UserClaimsPrincipalFactory` to return their own `ClaimsPrincipal`s.

* Wasn't sure if I should make `CreatePrincipal` **`async`** or not. Thoughts? :thinking: :thought_balloon: 

Thanks again for your consideration,
Brian

:car: :blue_car: ***["Let the good times roll..."](https://www.youtube.com/watch?v=7BDBzgHXf64)***