### PR TITLE
Modify UserStore and RoleStore DbSet protection level 

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/RoleStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/RoleStore.cs
@@ -439,7 +439,10 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
             get { return Context.Set<TRole>(); }
         }
 
-        private DbSet<TRoleClaim> RoleClaims { get { return Context.Set<TRoleClaim>(); } }
+        /// <summary>
+        /// Gets the RoleClaims DbSet.
+        /// </summary>
+        protected DbSet<TRoleClaim> RoleClaims { get { return Context.Set<TRoleClaim>(); } }
 
         /// <summary>
         /// Creates a entity representing a role claim.

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
@@ -146,12 +146,12 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         /// </summary>
         public IdentityErrorDescriber ErrorDescriber { get; set; }
 
-        private DbSet<TUser> UsersSet { get { return Context.Set<TUser>(); } }
-        private DbSet<TRole> Roles { get { return Context.Set<TRole>(); } }
-        private DbSet<TUserClaim> UserClaims { get { return Context.Set<TUserClaim>(); } }
-        private DbSet<TUserRole> UserRoles { get { return Context.Set<TUserRole>(); } }
-        private DbSet<TUserLogin> UserLogins { get { return Context.Set<TUserLogin>(); } }
-        private DbSet<TUserToken> UserTokens { get { return Context.Set<TUserToken>(); } }
+        protected DbSet<TUser> UsersSet { get { return Context.Set<TUser>(); } }
+        protected DbSet<TRole> Roles { get { return Context.Set<TRole>(); } }
+        protected DbSet<TUserClaim> UserClaims { get { return Context.Set<TUserClaim>(); } }
+        protected DbSet<TUserRole> UserRoles { get { return Context.Set<TUserRole>(); } }
+        protected DbSet<TUserLogin> UserLogins { get { return Context.Set<TUserLogin>(); } }
+        protected DbSet<TUserToken> UserTokens { get { return Context.Set<TUserToken>(); } }
 
         /// <summary>
         /// Called to create a new instance of a <see cref="IdentityUserRole{TKey}"/>.

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/UserStore.cs
@@ -145,12 +145,35 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         /// Gets or sets the <see cref="IdentityErrorDescriber"/> for any error that occurred with the current operation.
         /// </summary>
         public IdentityErrorDescriber ErrorDescriber { get; set; }
-
+            
+        /// <summary>
+        /// Gets the Users DbSet.
+        /// </summary>
         protected DbSet<TUser> UsersSet { get { return Context.Set<TUser>(); } }
+            
+        /// <summary>
+        /// Gets the Roles DbSet.
+        /// </summary>  
         protected DbSet<TRole> Roles { get { return Context.Set<TRole>(); } }
+            
+        /// <summary>
+        /// Gets the UserClaims DbSet.
+        /// </summary>
         protected DbSet<TUserClaim> UserClaims { get { return Context.Set<TUserClaim>(); } }
+            
+        /// <summary>
+        /// Gets the UserRoles DbSet.
+        /// </summary>
         protected DbSet<TUserRole> UserRoles { get { return Context.Set<TUserRole>(); } }
+            
+        /// <summary>
+        /// Gets the UserLogins DbSet.
+        /// </summary>   
         protected DbSet<TUserLogin> UserLogins { get { return Context.Set<TUserLogin>(); } }
+            
+        /// <summary>
+        /// Gets the UserTokens DbSet.
+        /// </summary>
         protected DbSet<TUserToken> UserTokens { get { return Context.Set<TUserToken>(); } }
 
         /// <summary>


### PR DESCRIPTION
The DbSet object can not be used when inheriting and rewriting certain methods.