### PR TITLE
netcoreapp2.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <AspNetCoreVersion>2.0.0-preview1-*</AspNetCoreVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <IdentityEFCompatVersion>2.2.1</IdentityEFCompatVersion>
-    <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
+    <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <OwinSecurityVersion>3.0.1</OwinSecurityVersion>

--- a/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
+++ b/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Identity sample MVC application on ASP.NET Core</Description>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <UserSecretsId>aspnetcore-b3d20cbe-418e-4bf2-a0f4-57f91d067e07</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity provider that uses Entity Framework Core.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;entityframeworkcore;identity;membership</PackageTags>
   </PropertyGroup>
@@ -16,9 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="$(CoreFxVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Identity.Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Asp.Net Identity Core store implementations.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Identity/Microsoft.AspNetCore.Identity.csproj
+++ b/src/Microsoft.AspNetCore.Identity/Microsoft.AspNetCore.Identity.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity is the membership system for building ASP.NET Core web applications, including membership, login, and user data. ASP.NET Core Identity allows you to add login features to your application and makes it easy to customize data about the logged in user.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
@@ -4,8 +4,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/test/Microsoft.AspNetCore.Identity.Test/Microsoft.AspNetCore.Identity.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Test/Microsoft.AspNetCore.Identity.Test.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
```
Microsoft.AspNet.Identity.AspNetCoreCompat.0.3.0-preview1-t00466eae3 -> net46
Microsoft.AspNetCore.Identity.2.0.0-preview1-t00466eae3 -> netcoreapp2.0
Microsoft.AspNetCore.Identity.EntityFrameworkCore.2.0.0-preview1-t00466eae3 -> netcoreapp2.0
Microsoft.AspNetCore.Identity.Specification.Tests.2.0.0-preview1-t00466eae3 -> netcoreapp2.0
```

`Microsoft.AspNet.Identity.AspNetCoreCompat` is for apps using pre-ASP.NET Core identity to be able to access ASP.NET Core Identity Databases.