### PR TITLE
Remove soon to be removed DisplayName set

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/IntegratedWebClientOpenIdConnectOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/IntegratedWebClientOpenIdConnectOptionsSetup.cs
@@ -32,7 +32,6 @@ namespace Microsoft.AspNetCore.Identity.Service.IntegratedWebClient
 
             if (!string.IsNullOrEmpty(_webApplicationOptions.Value.TokenRedirectUrn))
             {
-                options.DisplayName = null;
                 options.Events = new OpenIdConnectEvents
                 {
                     OnRedirectToIdentityProvider = (ctx) =>


### PR DESCRIPTION
This property was a leftover from auth 1.0 and isn't being used anymore and will be removed in https://github.com/aspnet/Security/pull/1206

There's a similar property on the AuthenticationScheme

@javiercn 