### PR TITLE
Switch back to netstandard2.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
-
+  
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
     <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>

--- a/build/common.props
+++ b/build/common.props
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
-    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" />
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,7 @@
     <IdentityEFCompatVersion>2.2.1</IdentityEFCompatVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
-    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <OwinSecurityVersion>3.0.1</OwinSecurityVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>

--- a/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
+++ b/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <Description>Identity sample MVC application on ASP.NET Core</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <UserSecretsId>aspnetcore-b3d20cbe-418e-4bf2-a0f4-57f91d067e07</UserSecretsId>
   </PropertyGroup>
 

--- a/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
+++ b/samples/IdentitySample.Mvc/IdentitySample.Mvc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <Import Project="..\..\build\dependencies.props" />
+  <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
     <Description>Identity sample MVC application on ASP.NET Core</Description>

--- a/samples/IdentitySample.Mvc/Startup.cs
+++ b/samples/IdentitySample.Mvc/Startup.cs
@@ -3,7 +3,6 @@ using IdentitySample.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,9 +46,6 @@ namespace IdentitySample
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/DeveloperCertificateMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/DeveloperCertificateMiddleware.cs
@@ -79,6 +79,7 @@ namespace Microsoft.AspNetCore.Diagnostics.Identity.Service
             await _next(context);
             void CreateDevelopmentCertificate()
             {
+#if NETCOREAPP2_0
                 using (var rsa = RSA.Create(2048))
                 {
                     var signingRequest = new CertificateRequest(
@@ -107,6 +108,10 @@ namespace Microsoft.AspNetCore.Diagnostics.Identity.Service
                         context.Response.StatusCode = StatusCodes.Status204NoContent;
                     };
                 }
+#elif NETSTANDARD2_0
+#else
+#error The target frameworks need to be updated.
+#endif
             }
 
             bool FoundDeveloperCertificate()

--- a/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
+++ b/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service Diagnostics Middleware.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
+++ b/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service Diagnostics Middleware.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity provider that uses Entity Framework Core.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;entityframeworkcore;identity;membership</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Identity.Service.Abstractions/Microsoft.AspNetCore.Identity.Service.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Abstractions/Microsoft.AspNetCore.Identity.Service.Abstractions.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core common types defining the main abstractions for Identity Service.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.Service.Core/Microsoft.AspNetCore.Identity.Service.Core.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Core/Microsoft.AspNetCore.Identity.Service.Core.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core common types implementing the main abstractions for Identity Service.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />

--- a/src/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service implementation based on ASP.NET Core Identity.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service in process client.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.Service.Mvc/Microsoft.AspNetCore.Identity.Service.Mvc.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Mvc/Microsoft.AspNetCore.Identity.Service.Mvc.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service integration for ASP.NET Core MVC.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Asp.Net Identity Core as a service store implementations.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Identity.Service/Microsoft.AspNetCore.Identity.Service.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service/Microsoft.AspNetCore.Identity.Service.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity Service implementation based on Entity Framework.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Identity.Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Asp.Net Identity Core store implementations.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Identity/Microsoft.AspNetCore.Identity.csproj
+++ b/src/Microsoft.AspNetCore.Identity/Microsoft.AspNetCore.Identity.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity is the membership system for building ASP.NET Core web applications, including membership, login, and user data. ASP.NET Core Identity allows you to add login features to your application and makes it easy to customize data about the logged in user.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>

--- a/src/Microsoft.Extensions.Identity.Core/Microsoft.Extensions.Identity.Core.csproj
+++ b/src/Microsoft.Extensions.Identity.Core/Microsoft.Extensions.Identity.Core.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity is the membership system for building ASP.NET Core web applications, including membership, login, and user data. ASP.NET Core Identity allows you to add login features to your application and makes it easy to customize data about the logged in user.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>
@@ -15,10 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(CoreFxVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Security.Claims" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.Identity.Stores/Microsoft.Extensions.Identity.Stores.csproj
+++ b/src/Microsoft.Extensions.Identity.Stores/Microsoft.Extensions.Identity.Stores.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core Identity is the membership system for building ASP.NET Core web applications, including membership, login, and user data. ASP.NET Core Identity allows you to add login features to your application and makes it easy to customize data about the logged in user.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>
@@ -14,11 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(CoreFxVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Security.Claims" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.InMemory.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/Microsoft.AspNetCore.Identity.InMemory.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.Abstractions.Test/Microsoft.AspNetCore.Identity.Service.Abstractions.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.Abstractions.Test/Microsoft.AspNetCore.Identity.Service.Abstractions.Test.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.Core.Test/CryptoUtilities.cs
+++ b/test/Microsoft.AspNetCore.Identity.Service.Core.Test/CryptoUtilities.cs
@@ -10,14 +10,24 @@ namespace Microsoft.AspNetCore.Identity.Service
     {
         internal static SecurityKey CreateTestKey(string id = "Test")
         {
-            using (var rsa = RSA.Create(2048))
+            var rsa = RSA.Create();
+            if (rsa.KeySize < 2048)
             {
-                SecurityKey key;
-                var parameters = rsa.ExportParameters(includePrivateParameters: true);
-                key = new RsaSecurityKey(parameters);
-                key.KeyId = id;
-                return key;
+                rsa.KeySize = 2048;
+                if (rsa.KeySize < 2048 && rsa is RSACryptoServiceProvider)
+                {
+                    rsa.Dispose();
+                    rsa = new RSACryptoServiceProvider(2048);
+                }
             }
+
+            SecurityKey key;
+            var parameters = rsa.ExportParameters(includePrivateParameters: true);
+            rsa.Dispose();
+
+            key = new RsaSecurityKey(parameters);
+            key.KeyId = id;
+            return key;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Identity.Service.Core.Test/Microsoft.AspNetCore.Identity.Service.Core.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.Core.Test/Microsoft.AspNetCore.Identity.Service.Core.Test.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.InMemory.Test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.InMemory.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.Test/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.InMemory.Test/Microsoft.AspNetCore.Identity.Service.InMemory.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.InMemory.Test/Microsoft.AspNetCore.Identity.Service.InMemory.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Service.Test/Microsoft.AspNetCore.Identity.Service.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Service.Test/Microsoft.AspNetCore.Identity.Service.Test.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Identity.Test/Microsoft.AspNetCore.Identity.Test.csproj
+++ b/test/Microsoft.AspNetCore.Identity.Test/Microsoft.AspNetCore.Identity.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Core identity looks straight forward

@javiercn can you update the new service stuff in this PR, there appears to be issues with your cryptohelpers:

CryptographyHelpers.cs(46,62): error CS1503: Argument 1: cannot convert from 'int' to 'string' [C:\GitHub\Identity\src\Microsoft.AspNetCore.Identity.Service.Core\Microsoft.AspNetCore.Identity.Service.Core.csproj]