### PR TITLE
[Design] Add ClientManager/Store/interfaces into Core - Iteration 1

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/ClientStore.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/ClientStore.cs
@@ -1,0 +1,518 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public class ClientStore<TClient, TScope, TClientClaim, TRedirectUri, TContext, TUserKey>
+        : ClientStoreBase<TClient, TScope, TClientClaim, TRedirectUri, TContext, TUserKey>
+        where TClient : IdentityClient<TUserKey, TScope, TClientClaim, TRedirectUri>
+        where TScope : IdentityClientScope, new()
+        where TClientClaim : IdentityClientClaim, new()
+        where TRedirectUri : IdentityClientRedirectUri, new()
+        where TContext : DbContext
+        where TUserKey : IEquatable<TUserKey>
+    {
+        public ClientStore(TContext context, IdentityErrorDescriber describer) : base(describer)
+            => Context = context;
+
+        public TContext Context { get; }
+
+        public DbSet<TClient> ClientsSet => Context.Set<TClient>();
+
+        public DbSet<TScope> Scopes => Context.Set<TScope>();
+
+        public DbSet<TClientClaim> ClientClaims => Context.Set<TClientClaim>();
+
+        public DbSet<TRedirectUri> RedirectUris => Context.Set<TRedirectUri>();
+
+        public override IQueryable<TClient> Clients => ClientsSet;
+
+        public bool AutoSaveChanges { get; set; } = true;
+
+        protected Task SaveChanges(CancellationToken cancellationToken)
+        {
+            return AutoSaveChanges ? Context.SaveChangesAsync(cancellationToken) : Task.CompletedTask;
+        }
+
+        public override async Task<IdentityResult> CreateAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            Context.Add(client);
+            await SaveChanges(cancellationToken);
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UpdateAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            Context.Attach(client);
+            client.ConcurrencyStamp = Guid.NewGuid().ToString();
+            Context.Update(client);
+            try
+            {
+                await SaveChanges(cancellationToken);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> DeleteAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            Context.Remove(client);
+            try
+            {
+                await SaveChanges(cancellationToken);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+            return IdentityResult.Success;
+        }
+
+        public override Task<TClient> FindByClientIdAsync(string clientId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            return Clients.SingleOrDefaultAsync(c => c.Id == clientId, cancellationToken);
+        }
+
+        public override Task<TClient> FindByNameAsync(string name, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            return Clients.SingleOrDefaultAsync(c => c.Name == name, cancellationToken);
+        }
+
+        public override async Task<IEnumerable<TClient>> FindByUserIdAsync(string userId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            var id = ConvertUserIdFromString(userId);
+            return await Clients.Where(c => c.UserId.Equals(id)).ToListAsync();
+        }
+
+        public override Task<TClient> FindByIdAsync(string ClientId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            var id = ConvertUserIdFromString(ClientId);
+            return ClientsSet.FindAsync(new object[] { id }, cancellationToken);
+        }
+
+        public override async Task<IEnumerable<string>> FindRegisteredUrisAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var redirectUris = await RedirectUris
+                .Where(ru => ru.ClientId.Equals(client.Id) && !ru.IsLogout)
+                .Select(ru => ru.Value)
+                .ToListAsync(cancellationToken);
+
+            return redirectUris;
+        }
+
+        public override async Task<IdentityResult> RegisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (redirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(redirectUri));
+            }
+
+            var existingRedirectUri = await RedirectUris.SingleOrDefaultAsync(
+                ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(redirectUri) && !ru.IsLogout);
+            if (existingRedirectUri != null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "A route with the same value already exists." });
+            }
+
+            RedirectUris.Add(CreateRedirectUri(client, redirectUri, isLogout: false));
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UnregisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (redirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(redirectUri));
+            }
+
+            var registeredUri = await RedirectUris
+                .SingleOrDefaultAsync(ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(redirectUri) && !ru.IsLogout);
+            if (registeredUri == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the redirect uri to unregister." });
+            }
+
+            RedirectUris.Remove(registeredUri);
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UpdateRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (oldRedirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(oldRedirectUri));
+            }
+
+            if (newRedirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(newRedirectUri));
+            }
+
+            var existingRedirectUri = await RedirectUris
+                .SingleOrDefaultAsync(ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(oldRedirectUri) && !ru.IsLogout);
+
+            if (existingRedirectUri == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the registered redirect uri to update." });
+            }
+
+            existingRedirectUri.Value = newRedirectUri;
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IEnumerable<string>> FindRegisteredLogoutUrisAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var redirectUris = await RedirectUris
+                .Where(ru => ru.ClientId.Equals(client.Id) && ru.IsLogout)
+                .Select(ru => ru.Value)
+                .ToListAsync(cancellationToken);
+
+            return redirectUris;
+        }
+
+        public override async Task<IdentityResult> RegisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (redirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(redirectUri));
+            }
+
+            var existingRedirectUri = await RedirectUris.SingleOrDefaultAsync(
+                ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(redirectUri) && ru.IsLogout);
+            if (existingRedirectUri != null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "A route with the same value already exists." });
+            }
+
+            RedirectUris.Add(CreateRedirectUri(client, redirectUri, isLogout: true));
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UnregisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (redirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(redirectUri));
+            }
+
+            var registeredUri = await RedirectUris
+                .SingleOrDefaultAsync(ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(redirectUri) && ru.IsLogout);
+            if (registeredUri == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the redirect uri to unregister." });
+            }
+
+            RedirectUris.Remove(registeredUri);
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UpdateLogoutRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (oldRedirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(oldRedirectUri));
+            }
+
+            if (newRedirectUri == null)
+            {
+                throw new ArgumentNullException(nameof(newRedirectUri));
+            }
+
+            var existingRedirectUri = await RedirectUris
+                .SingleOrDefaultAsync(ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(oldRedirectUri) && ru.IsLogout);
+
+            if (existingRedirectUri == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the registered redirect uri to update." });
+            }
+
+            existingRedirectUri.Value = newRedirectUri;
+
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IEnumerable<string>> FindScopesAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var scopes = await Scopes
+                .Where(s => s.ClientId.Equals(client.Id))
+                .Select(s => s.Value)
+                .ToListAsync(cancellationToken);
+
+            return scopes;
+        }
+
+        public override async Task<IdentityResult> AddScopeAsync(TClient client, string scope, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            var existingScope = await Scopes.SingleOrDefaultAsync(
+                ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(scope));
+            if (existingScope != null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "A scope with the same value already exists." });
+            }
+
+            Scopes.Add(CreateScope(client, scope));
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> UpdateScopeAsync(TClient client, string oldScope, string newScope, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (oldScope == null)
+            {
+                throw new ArgumentNullException(nameof(oldScope));
+            }
+
+            if (newScope == null)
+            {
+                throw new ArgumentNullException(nameof(newScope));
+            }
+
+            var existingScope = await Scopes
+                .SingleOrDefaultAsync(s => s.ClientId.Equals(client.Id) && s.Value.Equals(oldScope));
+            if (existingScope == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the scope to update." });
+            }
+
+            existingScope.Value = newScope;
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IdentityResult> RemoveScopeAsync(TClient client, string scope, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            var existingScope = await Scopes
+                .SingleOrDefaultAsync(ru => ru.ClientId.Equals(client.Id) && ru.Value.Equals(scope));
+            if (existingScope == null)
+            {
+                return IdentityResult.Failed(
+                    new IdentityError { Description = "We were unable to find the scope to remove." });
+            }
+
+            Scopes.Remove(existingScope);
+            return IdentityResult.Success;
+        }
+
+        public override async Task<IList<Claim>> GetClaimsAsync(TClient application, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return await ClientClaims.Where(ac => ac.ClientId.Equals(application.Id)).Select(c => c.ToClaim()).ToListAsync(cancellationToken);
+        }
+
+        public override Task AddClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+            foreach (var claim in claims)
+            {
+                ClientClaims.Add(CreateClientClaim(client, claim));
+            }
+            return Task.CompletedTask;
+        }
+
+        public override async Task ReplaceClaimAsync(TClient client, Claim oldClaim, Claim newClaim, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (oldClaim == null)
+            {
+                throw new ArgumentNullException(nameof(oldClaim));
+            }
+            if (newClaim == null)
+            {
+                throw new ArgumentNullException(nameof(newClaim));
+            }
+
+            var matchedClaims = await ClientClaims.Where(ac => ac.ClientId.Equals(client.Id) && ac.ClaimValue == oldClaim.Value && ac.ClaimType == oldClaim.Type).ToListAsync(cancellationToken);
+            foreach (var matchedClaim in matchedClaims)
+            {
+                matchedClaim.ClaimValue = newClaim.Value;
+                matchedClaim.ClaimType = newClaim.Type;
+            }
+        }
+
+        public override async Task RemoveClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+            foreach (var claim in claims)
+            {
+                var matchedClaims = await ClientClaims.Where(ac => ac.ClientId.Equals(client.Id) && ac.ClaimValue == claim.Value && ac.ClaimType == claim.Type).ToListAsync(cancellationToken);
+                foreach (var c in matchedClaims)
+                {
+                    ClientClaims.Remove(c);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
@@ -9,6 +9,10 @@
     <PackageTags>aspnetcore;entityframeworkcore;identity;membership</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Identity\Microsoft.AspNetCore.Identity.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Identity.Stores\Microsoft.Extensions.Identity.Stores.csproj" />

--- a/src/Microsoft.AspNetCore.Identity/IdentityBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Identity/IdentityBuilderExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    /// <summary>
+    /// Helper functions for configuring identity services.
+    /// </summary>
+    public static class IdentityBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the default token providers used to generate tokens for reset passwords, change email
+        /// and change telephone number operations, and for two factor authentication token generation.
+        /// </summary>
+        /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
+        public static IdentityBuilder AddDefaultTokenProviders(this IdentityBuilder builder)
+        {
+            var dataProtectionProviderType = typeof(DataProtectorTokenProvider<>).MakeGenericType(builder.UserType);
+            var phoneNumberProviderType = typeof(PhoneNumberTokenProvider<>).MakeGenericType(builder.UserType);
+            var emailTokenProviderType = typeof(EmailTokenProvider<>).MakeGenericType(builder.UserType);
+            var authenticatorProviderType = typeof(AuthenticatorTokenProvider<>).MakeGenericType(builder.UserType);
+            return builder.AddTokenProvider(TokenOptions.DefaultProvider, dataProtectionProviderType)
+                .AddTokenProvider(TokenOptions.DefaultEmailProvider, emailTokenProviderType)
+                .AddTokenProvider(TokenOptions.DefaultPhoneProvider, phoneNumberProviderType)
+                .AddTokenProvider(TokenOptions.DefaultAuthenticatorProvider, authenticatorProviderType);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="SignInManager{TUser}"/> for the <seealso cref="IdentityBuilder.UserType"/>.
+        /// </summary>
+        /// <typeparam name="TSignInManager">The type of the sign in manager to add.</typeparam>
+        /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
+        public static IdentityBuilder AddSignInManager<TSignInManager>(this IdentityBuilder builder) where TSignInManager : class
+        {
+            var managerType = typeof(SignInManager<>).MakeGenericType(builder.UserType);
+            var customType = typeof(TSignInManager);
+            if (managerType == customType ||
+                !managerType.GetTypeInfo().IsAssignableFrom(customType.GetTypeInfo()))
+            {
+                throw new InvalidOperationException(AspNetIdentityResources.FormatInvalidManagerType(customType.Name, "SignInManager", builder.UserType.Name));
+            }
+            builder.Services.AddScoped(typeof(TSignInManager), services => services.GetRequiredService(managerType));
+            builder.Services.AddScoped(managerType, typeof(TSignInManager));
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/ClientManager.cs
+++ b/src/Microsoft.Extensions.Identity.Core/ClientManager.cs
@@ -1,0 +1,499 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    ///
+    public class ClientManager<TClient> : IDisposable where TClient : class
+    {
+        private bool _disposed;
+
+        public ClientManager(
+            IClientStore<TClient> store,
+            IPasswordHasher<TClient> passwordHasher,
+            IEnumerable<IClientValidator<TClient>> clientValidators,
+            ILogger<ClientManager<TClient>> logger)
+        {
+            Store = store;
+            PasswordHasher = passwordHasher;
+            ClientValidators = clientValidators;
+            Logger = Logger;
+        }
+
+        public IClientStore<TClient> Store { get; set; }
+        public IPasswordHasher<TClient> PasswordHasher { get; set; }
+        public IEnumerable<IClientValidator<TClient>> ClientValidators { get; set; }
+        public ILogger<ClientManager<TClient>> Logger { get; set; }
+        public CancellationToken CancellationToken { get; set; }
+
+        public virtual bool SupportsQueryableClients
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return Store is IQueryableUserStore<TClient>;
+            }
+        }
+
+        public virtual IQueryable<TClient> Clients
+        {
+            get
+            {
+                var queryableStore = Store as IQueryableClientStore<TClient>;
+                if (queryableStore == null)
+                {
+                    throw new NotSupportedException("Store not IQueryableClientStore");
+                }
+                return queryableStore.Clients;
+            }
+        }
+
+        public Task<TClient> FindByIdAsync(string ClientId)
+        {
+            return Store.FindByIdAsync(ClientId, CancellationToken);
+        }
+
+        public Task<TClient> FindByNameAsync(string name)
+        {
+            return Store.FindByNameAsync(name, CancellationToken.None);
+        }
+
+        public virtual async Task<IdentityResult> CreateAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var result = await ValidateClientAsync(client);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await Store.CreateAsync(client, CancellationToken);
+        }
+
+        public virtual async Task<IdentityResult> DeleteAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            return await Store.DeleteAsync(client, CancellationToken);
+        }
+
+        public virtual async Task<IdentityResult> UpdateAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var result = await ValidateClientAsync(client);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await Store.UpdateAsync(client, CancellationToken);
+        }
+
+        private async Task<IdentityResult> ValidateClientAsync(TClient client)
+        {
+            var errors = new List<IdentityError>();
+            foreach (var v in ClientValidators)
+            {
+                var result = await v.ValidateAsync(this, client);
+                if (!result.Succeeded)
+                {
+                    errors.AddRange(result.Errors);
+                }
+            }
+
+            if (errors.Count > 0)
+            {
+                return IdentityResult.Failed(errors.ToArray());
+            }
+
+            return IdentityResult.Success;
+        }
+
+        public Task<string> GetClientIdAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            return Store.GetIdAsync(client, CancellationToken);
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+
+        public Task<string> GenerateClientSecretAsync()
+        {
+            return Task.FromResult(Guid.NewGuid().ToString());
+        }
+
+        public async Task<IdentityResult> AddClientSecretAsync(TClient client, string clientSecret)
+        {
+            ThrowIfDisposed();
+            var store = GetClientSecretStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var hash = await store.GetClientSecretHashAsync(client, CancellationToken);
+            if (hash != null)
+            {
+                Logger.LogWarning(1, "User {clientId} already has a password.", await GetClientIdAsync(client));
+                return IdentityResult.Failed();
+            }
+            var result = await UpdateClientSecretHashAsync(store, client, clientSecret);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await UpdateAsync(client);
+        }
+
+        public async Task<IdentityResult> ChangeClientSecretAsync(TClient client, string newClientSecret)
+        {
+            ThrowIfDisposed();
+            var store = GetClientSecretStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var result = await UpdateClientSecretHashAsync(store, client, newClientSecret);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await UpdateAsync(client);
+        }
+
+        public async Task<IdentityResult> RemoveClientSecretAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            var store = GetClientSecretStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var result = await UpdateClientSecretHashAsync(store, client, clientSecret: null);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await UpdateAsync(client);
+        }
+
+        private IClientRedirectUriStore<TClient> GetRedirectUriStore()
+        {
+            if (Store is IClientRedirectUriStore<TClient> cast)
+            {
+                return cast;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public async Task<IdentityResult> RegisterRedirectUriAsync(TClient client, string redirectUri)
+        {
+            var redirectStore = GetRedirectUriStore();
+            var result = await redirectStore.RegisterRedirectUriAsync(client, redirectUri, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await redirectStore.UpdateAsync(client, CancellationToken);
+        }
+
+        public Task<IEnumerable<string>> FindRegisteredUrisAsync(TClient client)
+        {
+            var redirectStore = GetRedirectUriStore();
+            return redirectStore.FindRegisteredUrisAsync(client, CancellationToken);
+        }
+
+        public Task<IEnumerable<string>> FindRegisteredLogoutUrisAsync(TClient client)
+        {
+            var redirectStore = GetRedirectUriStore();
+            return redirectStore.FindRegisteredLogoutUrisAsync(client, CancellationToken);
+        }
+
+        public async Task<IdentityResult> UnregisterRedirectUriAsync(TClient client, string redirectUri)
+        {
+            var redirectStore = GetRedirectUriStore();
+            var result = await redirectStore.UnregisterRedirectUriAsync(client, redirectUri, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await redirectStore.UpdateAsync(client, CancellationToken);
+        }
+
+        public async Task<IdentityResult> UpdateRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri)
+        {
+            var redirectStore = GetRedirectUriStore();
+            var result = await redirectStore.UpdateRedirectUriAsync(client, oldRedirectUri, newRedirectUri, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await redirectStore.UpdateAsync(client, CancellationToken);
+        }
+
+        public async Task<bool> ValidateClientCredentialsAsync(string clientId, string clientSecret)
+        {
+            var client = await FindByIdAsync(clientId);
+            if (client == null)
+            {
+                return false;
+            }
+
+            var clientSecretStore = GetClientSecretStore();
+            if (!await clientSecretStore.HasClientSecretAsync(client, CancellationToken))
+            {
+                // Should we fail if clientSecret != null?
+                return true;
+            }
+
+            if (clientSecret == null)
+            {
+                return false;
+            }
+
+            var result = await VerifyClientSecretAsync(clientSecretStore, client, clientSecret);
+            if (result == PasswordVerificationResult.SuccessRehashNeeded)
+            {
+                await UpdateClientSecretHashAsync(clientSecretStore, client, clientSecret);
+                await UpdateAsync(client);
+                return true;
+            }
+
+            return result == PasswordVerificationResult.Success;
+        }
+
+        private async Task<IdentityResult> UpdateClientSecretHashAsync(
+            IClientSecretStore<TClient> clientSecretStore,
+            TClient client,
+            string clientSecret)
+        {
+            var hash = PasswordHasher.HashPassword(client, clientSecret);
+            await clientSecretStore.SetClientSecretHashAsync(client, hash, CancellationToken);
+            return IdentityResult.Success;
+        }
+
+        protected virtual async Task<PasswordVerificationResult> VerifyClientSecretAsync(
+            IClientSecretStore<TClient> store,
+            TClient client,
+            string clientSecret)
+        {
+            var hash = await store.GetClientSecretHashAsync(client, CancellationToken);
+            if (hash == null)
+            {
+                return PasswordVerificationResult.Failed;
+            }
+
+            return PasswordHasher.VerifyHashedPassword(client, hash, clientSecret);
+        }
+
+        private IClientSecretStore<TClient> GetClientSecretStore()
+        {
+            if (Store is IClientSecretStore<TClient> cast)
+            {
+                return cast;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public Task<IEnumerable<string>> FindScopesAsync(TClient client)
+        {
+            var scopeStore = GetScopeStore();
+            return scopeStore.FindScopesAsync(client, CancellationToken);
+        }
+
+        public async Task<IdentityResult> AddScopeAsync(TClient client, string scope)
+        {
+            var scopeStore = GetScopeStore();
+            var result = await scopeStore.AddScopeAsync(client, scope, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await scopeStore.UpdateAsync(client, CancellationToken);
+        }
+
+        public async Task<IdentityResult> RemoveScopeAsync(TClient client, string scope)
+        {
+            var scopeStore = GetScopeStore();
+            var result = await scopeStore.RemoveScopeAsync(client, scope, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await scopeStore.UpdateAsync(client, CancellationToken);
+        }
+
+        public async Task<IdentityResult> UpdateScopeAsync(TClient client, string oldScope, string newScope)
+        {
+            var scopeStore = GetScopeStore();
+            var result = await scopeStore.UpdateScopeAsync(client, oldScope, newScope, CancellationToken);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            return await scopeStore.UpdateAsync(client, CancellationToken);
+        }
+
+        private IClientScopeStore<TClient> GetScopeStore()
+        {
+            if (Store is IClientScopeStore<TClient> cast)
+            {
+                return cast;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public virtual Task<IdentityResult> AddClaimAsync(TClient client, Claim claim)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (claim == null)
+            {
+                throw new ArgumentNullException(nameof(claim));
+            }
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            return AddClaimsAsync(client, new Claim[] { claim });
+        }
+
+        public virtual async Task<IdentityResult> AddClaimsAsync(TClient client, IEnumerable<Claim> claims)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            await claimStore.AddClaimsAsync(client, claims, CancellationToken);
+            return await UpdateAsync(client);
+        }
+
+        public virtual async Task<IdentityResult> ReplaceClaimAsync(TClient client, Claim claim, Claim newClaim)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (claim == null)
+            {
+                throw new ArgumentNullException(nameof(claim));
+            }
+            if (newClaim == null)
+            {
+                throw new ArgumentNullException(nameof(newClaim));
+            }
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            await claimStore.ReplaceClaimAsync(client, claim, newClaim, CancellationToken);
+            return await UpdateAsync(client);
+        }
+
+        public virtual Task<IdentityResult> RemoveClaimAsync(TClient client, Claim claim)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (claim == null)
+            {
+                throw new ArgumentNullException(nameof(claim));
+            }
+            return RemoveClaimsAsync(client, new Claim[] { claim });
+        }
+
+        public virtual async Task<IdentityResult> RemoveClaimsAsync(TClient client, IEnumerable<Claim> claims)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+
+            await claimStore.RemoveClaimsAsync(client, claims, CancellationToken);
+            return await UpdateAsync(client);
+        }
+
+        public virtual async Task<IList<Claim>> GetClaimsAsync(TClient client)
+        {
+            ThrowIfDisposed();
+            var claimStore = GetClientClaimStore();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            return await claimStore.GetClaimsAsync(client, CancellationToken);
+        }
+
+        private IClientClaimStore<TClient> GetClientClaimStore()
+        {
+            if (Store is IClientClaimStore<TClient> cast)
+            {
+                return cast;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        protected void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientClaimStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientClaimStore.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientClaimStore<TClient> : IClientStore<TClient> where TClient : class
+    {
+        Task<IList<Claim>> GetClaimsAsync(TClient client, CancellationToken cancellationToken);
+        Task AddClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken);
+        Task ReplaceClaimAsync(TClient client, Claim claim, Claim newClaim, CancellationToken cancellationToken);
+        Task RemoveClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientClaimsPrincipalFactory.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientClaimsPrincipalFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IApplicationClaimsPrincipalFactory<TClient>
+    {
+        Task<ClaimsPrincipal> CreateAsync(TClient client);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientRedirectUriStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientRedirectUriStore.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientRedirectUriStore<TClient> : IClientStore<TClient> where TClient : class
+    {
+        Task<IEnumerable<string>> FindRegisteredUrisAsync(TClient client, CancellationToken cancellationToken);
+        Task<IEnumerable<string>> FindRegisteredLogoutUrisAsync(TClient client, CancellationToken cancellationToken);
+        Task<IdentityResult> RegisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+        Task<IdentityResult> RegisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+        Task<IdentityResult> UnregisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+        Task<IdentityResult> UnregisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+        Task<IdentityResult> UpdateRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken);
+        Task<IdentityResult> UpdateLogoutRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientScopeStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientScopeStore.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientScopeStore<TClient> : IClientStore<TClient> where TClient : class
+    {
+        Task<IEnumerable<string>> FindScopesAsync(TClient client, CancellationToken cancellationToken);
+        Task<IdentityResult> AddScopeAsync(TClient client, string scope, CancellationToken cancellationToken);
+        Task<IdentityResult> UpdateScopeAsync(TClient client, string oldScope, string newScope, CancellationToken cancellationToken);
+        Task<IdentityResult> RemoveScopeAsync(TClient client, string scope, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientSecretStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientSecretStore.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientSecretStore<TClient> : IClientStore<TClient> where TClient : class
+    {
+        Task SetClientSecretHashAsync(TClient client, string hash, CancellationToken cancellationToken);
+        Task<string> GetClientSecretHashAsync(TClient client, CancellationToken cancellationToken);
+        Task<bool> HasClientSecretAsync(TClient client, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientStore.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientStore<TClient> : IDisposable where TClient : class
+    {
+        Task<IdentityResult> CreateAsync(TClient client, CancellationToken cancellationToken);
+        Task<IdentityResult> UpdateAsync(TClient client, CancellationToken cancellationToken);
+        Task<IdentityResult> DeleteAsync(TClient client, CancellationToken cancellationToken);
+        Task<TClient> FindByIdAsync(string clientId, CancellationToken cancellationToken);
+        Task<IEnumerable<TClient>> FindByUserIdAsync(string userId, CancellationToken cancellationToken);
+        Task<TClient> FindByNameAsync(string name, CancellationToken cancellationToken);
+        Task<string> GetIdAsync(TClient client, CancellationToken cancellationToken);
+        Task<string> GetNameAsync(TClient client, CancellationToken cancellationToken);
+        Task<string> GetUserIdAsync(TClient client, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IClientValidator.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IClientValidator.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IClientValidator<TClient> where TClient : class
+    {
+        Task<IdentityResult> ValidateAsync(ClientManager<TClient> manager, TClient Client);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/IQueryableClientStore.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IQueryableClientStore.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public interface IQueryableClientStore<TClient> : IClientStore<TClient> where TClient : class
+    {
+        IQueryable<TClient> Clients { get; }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Core/Microsoft.Extensions.Identity.Core.csproj
+++ b/src/Microsoft.Extensions.Identity.Core/Microsoft.Extensions.Identity.Core.csproj
@@ -10,6 +10,10 @@
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />

--- a/src/Microsoft.Extensions.Identity.Stores/ClientStoreBase.cs
+++ b/src/Microsoft.Extensions.Identity.Stores/ClientStoreBase.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public abstract class ClientStoreBase<TClient, TScope, TClientClaim, TRedirectUri, TContext, TUserKey>
+        : IClientRedirectUriStore<TClient>,
+        IClientClaimStore<TClient>,
+        IClientSecretStore<TClient>,
+        IClientScopeStore<TClient>,
+        IQueryableClientStore<TClient>
+        where TClient : IdentityClient<TUserKey, TScope, TClientClaim, TRedirectUri>
+        where TScope : IdentityClientScope, new()
+        where TClientClaim : IdentityClientClaim, new()
+        where TRedirectUri : IdentityClientRedirectUri, new()
+        where TUserKey : IEquatable<TUserKey>
+    {
+        private bool _disposed;
+
+        public ClientStoreBase(IdentityErrorDescriber describer)
+        {
+            if (describer == null)
+            {
+                throw new ArgumentNullException(nameof(describer));
+            }
+
+            ErrorDescriber = describer;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IdentityErrorDescriber"/> for any error that occurred with the current operation.
+        /// </summary>
+        public IdentityErrorDescriber ErrorDescriber { get; set; }
+
+        public abstract IQueryable<TClient> Clients { get; }
+
+        public abstract Task<IdentityResult> CreateAsync(TClient client, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> UpdateAsync(TClient client, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> DeleteAsync(TClient client, CancellationToken cancellationToken);
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+
+        public abstract Task<TClient> FindByClientIdAsync(string clientId, CancellationToken cancellationToken);
+
+        public abstract Task<TClient> FindByNameAsync(string name, CancellationToken cancellationToken);
+
+        public abstract Task<IEnumerable<TClient>> FindByUserIdAsync(string userId, CancellationToken cancellationToken);
+
+        public abstract Task<TClient> FindByIdAsync(string clientId, CancellationToken cancellationToken);
+
+        public virtual Task<string> GetIdAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            return Task.FromResult(client.Id);
+        }
+
+        public virtual Task<string> GetUserIdAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            var id = ConvertUserIdToString(client.UserId);
+            return Task.FromResult(id);
+        }
+
+        public virtual Task<string> GetNameAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            return Task.FromResult(client.Name);
+        }
+
+        public abstract Task<IEnumerable<string>> FindRegisteredUrisAsync(TClient client, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> RegisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+
+        public virtual TRedirectUri CreateRedirectUri(TClient client, string redirectUri, bool isLogout)
+            => new TRedirectUri
+            {
+                ClientId = client.Id,
+                IsLogout = isLogout,
+                Value = redirectUri
+            };
+
+        public abstract Task<IdentityResult> UnregisterRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> UpdateRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken);
+
+        public abstract Task<IEnumerable<string>> FindRegisteredLogoutUrisAsync(TClient client, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> RegisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> UnregisterLogoutRedirectUriAsync(TClient client, string redirectUri, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> UpdateLogoutRedirectUriAsync(TClient client, string oldRedirectUri, string newRedirectUri, CancellationToken cancellationToken);
+
+        protected void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        public virtual string ConvertUserIdToString(TUserKey id)
+        {
+            if (Equals(id, default(TUserKey)))
+            {
+                return null;
+            }
+            return id.ToString();
+        }
+
+        public virtual TUserKey ConvertUserIdFromString(string id)
+        {
+            if (id == null)
+            {
+                return default(TUserKey);
+            }
+            return (TUserKey)TypeDescriptor.GetConverter(typeof(TUserKey)).ConvertFromInvariantString(id);
+        }
+
+        public virtual Task SetClientSecretHashAsync(TClient client, string clientSecretHash, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            client.ClientSecretHash = clientSecretHash;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetClientSecretHashAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            return Task.FromResult(client.ClientSecretHash);
+        }
+
+        public virtual Task<bool> HasClientSecretAsync(TClient client, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ThrowIfDisposed();
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            return Task.FromResult(client.ClientSecretHash != null);
+        }
+
+        public abstract Task<IEnumerable<string>> FindScopesAsync(TClient client, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> AddScopeAsync(TClient client, string scope, CancellationToken cancellationToken);
+
+        public virtual TScope CreateScope(TClient client, string scope)
+        {
+            return new TScope
+            {
+                ClientId = client.Id,
+                Value = scope
+            };
+        }
+
+        public abstract Task<IdentityResult> UpdateScopeAsync(TClient client, string oldScope, string newScope, CancellationToken cancellationToken);
+
+        public abstract Task<IdentityResult> RemoveScopeAsync(TClient client, string scope, CancellationToken cancellationToken);
+
+        public abstract Task<IList<Claim>> GetClaimsAsync(TClient application, CancellationToken cancellationToken);
+
+        public abstract Task AddClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken);
+
+        public virtual TClientClaim CreateClientClaim(TClient client, Claim claim) =>
+            new TClientClaim
+            {
+                ClientId = client.Id,
+                ClaimType = claim.Type,
+                ClaimValue = claim.Value
+            };
+
+        public abstract Task ReplaceClaimAsync(TClient client, Claim oldClaim, Claim newClaim, CancellationToken cancellationToken);
+
+        public abstract Task RemoveClaimsAsync(TClient client, IEnumerable<Claim> claims, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Stores/IdentityClient.cs
+++ b/src/Microsoft.Extensions.Identity.Stores/IdentityClient.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public class IdentityClient : IdentityClient<string> { }
+
+    public class IdentityClient<TUserKey> :
+        IdentityClient<TUserKey, IdentityClientScope, IdentityClientClaim, IdentityClientRedirectUri>
+        where TUserKey : IEquatable<TUserKey>
+    { }
+
+    public class IdentityClient<TUserKey, TScope, TApplicationClaim, TRedirectUri>
+        where TUserKey : IEquatable<TUserKey>
+        where TScope : IdentityClientScope
+        where TApplicationClaim : IdentityClientClaim
+        where TRedirectUri : IdentityClientRedirectUri
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public TUserKey UserId { get; set; }
+        public string ClientSecretHash { get; set; }
+        public string ConcurrencyStamp { get; set; }
+        public ICollection<TScope> Scopes { get; set; }
+        public ICollection<TApplicationClaim> Claims { get; set; }
+        public ICollection<TRedirectUri> RedirectUris { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Stores/IdentityClientClaim.cs
+++ b/src/Microsoft.Extensions.Identity.Stores/IdentityClientClaim.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public class IdentityClientClaim
+    {
+        public int Id { get; set; }
+        public string ClientId { get; set; }
+        public string ClaimType { get; set; }
+        public string ClaimValue { get; set; }
+
+        public Claim ToClaim() => new Claim(ClaimType, ClaimValue);
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Stores/IdentityClientRedirectUri.cs
+++ b/src/Microsoft.Extensions.Identity.Stores/IdentityClientRedirectUri.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public class IdentityClientRedirectUri
+    {
+        public string Id { get; set; }
+        public string ClientId { get; set; }
+        public bool IsLogout { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Stores/IdentityClientScope.cs
+++ b/src/Microsoft.Extensions.Identity.Stores/IdentityClientScope.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Identity
+{
+    public class IdentityClientScope
+    {
+        public string Id { get; set; }
+        public string ClientId { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Identity.Stores/Microsoft.Extensions.Identity.Stores.csproj
+++ b/src/Microsoft.Extensions.Identity.Stores/Microsoft.Extensions.Identity.Stores.csproj
@@ -10,6 +10,10 @@
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />


### PR DESCRIPTION
Issue: https://github.com/aspnet/Identity/issues/1244

## Iteration 1
- I'm starting on these PRs now to make sure we have all the support we need in core identity to do this later. 
- We can also use these PRs to review each of the interfaces/methods as we are adding them to core.
- The main change other than moving stuff was renaming Application => Client (new placeholder name, open to other ideas).
- This iteration focuses on pulling everything in from Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore and also will focus on defining the surface area of ClientManager/ClientStore/IdentityClient and associated related entities. (aka the low level building blocks)
- The next iteration will flesh out registration AddIdentity overloads, and how to opt into/out of Roles/Client functionality/schema, and absorbing the IdentityServiceSpecfication tests. (aka make it all work again)

## New types
`Microsoft.Extensions.Identity.Core`:
+ `IdentityBuilder` <= `Microsoft.AspNet.Identity`
+ `ClientManager`
+ `IClientStore`
+ `IClientClaimsPrincipalFactory`
+ `IClientClaimStore`
+ `IClientRedirectUriStore`
+ `IClientScopeStore`
+ `IClientSecretStore`
+ `IClientValidator`
+ `IQueryableClientStore`

`Microsoft.Extensions.Identity.Stores`:
+ `ClientStoreBase`
+ `IdentityClient`
+ `IdentityClientClaim`
+ `IdentityClientRedirectUri`
+ `IdentityClientScope`

`Microsoft.AspNet.Identity.EntityFrameworkCore`:
+ `ClientStore`

@javiercn take a look when you have a chance, since you basically followed the existing manager/store patterns, most of the classes were moved as is with some slight renaming + refactoring.

I did have a question about Application's ClientId/UserId.  Today Application's have both a TKey id and a clientId, but clientId's must be unique since you can look them up via the Store API.  So Is there any reason we can't just use the ClientId as the key?  Its much nicer since its always a string so it eliminates a generic.  Also are all Applications tied to a single user since there's a FindByUserId as well?

cc @ajcvickers @danroth27 @blowdart 


