### PR TITLE
Fixes issue #1370

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -124,7 +124,15 @@ namespace Microsoft.AspNetCore.Identity
                 throw new ArgumentNullException(nameof(principal));
             }
             return principal?.Identities != null &&
-                principal.Identities.Any(i => i.AuthenticationType == IdentityConstants.ApplicationScheme);
+                principal.Identities.Any((i) => 
+                {
+                    try{
+                      return i.AuthenticationType == IdentityConstants.ApplicationScheme;                        
+                    }
+                    catch(UnauthorizedAccessException e){
+                        return false;
+                    }
+                });
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Identity/SignInManager.cs
+++ b/src/Microsoft.AspNetCore.Identity/SignInManager.cs
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Identity
                     try{
                       return i.AuthenticationType == IdentityConstants.ApplicationScheme;                        
                     }
-                    catch(UnauthorizedAccessException e){
+                    catch(UnauthorizedAccessException){
                         return false;
                     }
                 });


### PR DESCRIPTION
As described in the issue #1370 -- the method `SignInManager.IsSignedIn(ClaimsPrincipal)` throws when the request has a Windows Identity attached to it.

The root cause for this is described in Ph1ll's comment on [this issue](https://github.com/aspnet/IISIntegration/issues/231). 

I believe this proposed solution keeps the expected behavior of the method, while fixing a relevant issue for applications on the enterprise.

This issue is blocking adoption of ASP.NET Core as it is preventing the deployment to production of an application in a Fortune 500 pharmaceutical company.

