### PR TITLE
Fix params name and AddRoles

### DIFF
--- a/src/Microsoft.Extensions.Identity.Core/IdentityBuilder.cs
+++ b/src/Microsoft.Extensions.Identity.Core/IdentityBuilder.cs
@@ -103,10 +103,10 @@ namespace Microsoft.AspNetCore.Identity
         /// <summary>
         /// Adds an <see cref="IUserStore{TUser}"/> for the <seealso cref="UserType"/>.
         /// </summary>
-        /// <typeparam name="TUser">The user type held in the store.</typeparam>
+        /// <typeparam name="TStore">The user store type.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
-        public virtual IdentityBuilder AddUserStore<TUser>() where TUser : class
-            => AddScoped(typeof(IUserStore<>).MakeGenericType(UserType), typeof(TUser));
+        public virtual IdentityBuilder AddUserStore<TStore>() where TStore : class
+            => AddScoped(typeof(IUserStore<>).MakeGenericType(UserType), typeof(TStore));
 
         /// <summary>
         /// Adds a token provider.
@@ -165,7 +165,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual IdentityBuilder AddRoles<TRole>() where TRole : class
         {
             RoleType = typeof(TRole);
-            AddRoleStore<TRole>();
             AddRoleValidator<RoleValidator<TRole>>();
             Services.TryAddScoped<RoleManager<TRole>, RoleManager<TRole>>();
             return this;
@@ -189,15 +188,15 @@ namespace Microsoft.AspNetCore.Identity
         /// <summary>
         /// Adds a <see cref="IRoleStore{TRole}"/> for the <seealso cref="RoleType"/>.
         /// </summary>
-        /// <typeparam name="TRole">The role type held in the store.</typeparam>
+        /// <typeparam name="TStore">The role store.</typeparam>
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
-        public virtual IdentityBuilder AddRoleStore<TRole>() where TRole : class
+        public virtual IdentityBuilder AddRoleStore<TStore>() where TStore : class
         {
             if (RoleType == null)
             {
                 throw new InvalidOperationException(Resources.NoRoleType);
             }
-            return AddScoped(typeof(IRoleStore<>).MakeGenericType(RoleType), typeof(TRole));
+            return AddScoped(typeof(IRoleStore<>).MakeGenericType(RoleType), typeof(TStore));
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.InMemory.Test/FunctionalTest.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/test/Microsoft.AspNetCore.Identity.Test/IdentityBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.Test/IdentityBuilderTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,6 +16,31 @@ namespace Microsoft.AspNetCore.Identity.Test
 {
     public class IdentityBuilderTest
     {
+        [Fact]
+        public void AddRolesServicesAdded()
+        {
+            var services = new ServiceCollection();
+            services.AddIdentityCore<TestUser>(o => { })
+                .AddRoles<TestRole>()
+                .AddRoleStore<NoopRoleStore>();
+            var sp = services.BuildServiceProvider();
+            Assert.NotNull(sp.GetRequiredService<IRoleValidator<TestRole>>());
+            Assert.IsType<NoopRoleStore>(sp.GetRequiredService<IRoleStore<TestRole>>());
+            Assert.NotNull(sp.GetRequiredService<RoleManager<TestRole>>());
+        }
+
+        [Fact]
+        public void AddRolesWithoutStoreWillError()
+        {
+            var services = new ServiceCollection();
+            services.AddIdentityCore<TestUser>(o => { })
+                .AddRoles<TestRole>();
+            var sp = services.BuildServiceProvider();
+            Assert.NotNull(sp.GetRequiredService<IRoleValidator<TestRole>>());
+            Assert.Null(sp.GetService<IRoleStore<TestRole>>());
+            Assert.Throws<InvalidOperationException>(() => sp.GetService<RoleManager<TestRole>>());
+        }
+
 
         [Fact]
         public void CanOverrideUserStore()


### PR DESCRIPTION
AddRoles should not be adding a store, that's done by the store
implementation, it should only be registering the role services.  Also
fixed the TUser/TRole generic parameters names since they were actually
the store types

Fixes https://github.com/aspnet/Identity/issues/1382
https://github.com/aspnet/Identity/issues/1379

@ajcvickers 