### PR TITLE
XML doc comments changes

### DIFF
--- a/src/Microsoft.AspNetCore.Identity/DataProtectionTokenProviderOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/DataProtectionTokenProviderOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Identity
     public class DataProtectionTokenProviderOptions
     {
         /// <summary>
-        /// Gets or sets the name of the <see cref="DataProtectorTokenProvider{TUser}"/>.
+        /// Gets or sets the name of the <see cref="DataProtectorTokenProvider{TUser}"/>. Defaults to DataProtectorTokenProvider.
         /// </summary>
         /// <value>
         /// The name of the <see cref="DataProtectorTokenProvider{TUser}"/>.
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Identity
         public string Name { get; set; } = "DataProtectorTokenProvider";
 
         /// <summary>
-        /// Gets or sets the amount of time a generated token remains valid.
+        /// Gets or sets the amount of time a generated token remains valid. Defaults to 1 day.
         /// </summary>
         /// <value>
         /// The amount of time a generated token remains valid.

--- a/src/Microsoft.AspNetCore.Identity/SecurityStampValidatorOptions.cs
+++ b/src/Microsoft.AspNetCore.Identity/SecurityStampValidatorOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Identity
     public class SecurityStampValidatorOptions
     {
         /// <summary>
-        /// Gets or sets the <see cref="TimeSpan"/> after which security stamps are re-validated.
+        /// Gets or sets the <see cref="TimeSpan"/> after which security stamps are re-validated. Defaults to 30 minutes.
         /// </summary>
         /// <value>
         /// The <see cref="TimeSpan"/> after which security stamps are re-validated.

--- a/src/Microsoft.Extensions.Identity.Core/ClaimsIdentityOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/ClaimsIdentityOptions.cs
@@ -11,35 +11,23 @@ namespace Microsoft.AspNetCore.Identity
     public class ClaimsIdentityOptions
     {
         /// <summary>
-        /// Gets or sets the ClaimType used for a Role claim.
+        /// Gets or sets the ClaimType used for a Role claim. Defaults to <see cref="ClaimTypes.Role"/>.
         /// </summary>
-        /// <remarks>
-        /// This defaults to <see cref="ClaimTypes.Role"/>.
-        /// </remarks>
         public string RoleClaimType { get; set; } = ClaimTypes.Role;
 
         /// <summary>
-        /// Gets or sets the ClaimType used for the user name claim.
+        /// Gets or sets the ClaimType used for the user name claim. Defaults to <see cref="ClaimTypes.Name"/>.
         /// </summary>
-        /// <remarks>
-        /// This defaults to <see cref="ClaimTypes.Name"/>.
-        /// </remarks>
         public string UserNameClaimType { get; set; } = ClaimTypes.Name;
 
         /// <summary>
-        /// Gets or sets the ClaimType used for the user identifier claim.
+        /// Gets or sets the ClaimType used for the user identifier claim. Defaults to <see cref="ClaimTypes.NameIdentifier"/>.
         /// </summary>
-        /// <remarks>
-        /// This defaults to <see cref="ClaimTypes.NameIdentifier"/>.
-        /// </remarks>
         public string UserIdClaimType { get; set; } = ClaimTypes.NameIdentifier;
 
         /// <summary>
-        /// Gets or sets the ClaimType used for the security stamp claim.
+        /// Gets or sets the ClaimType used for the security stamp claim. Defaults to "AspNet.Identity.SecurityStamp".
         /// </summary>
-        /// <remarks>
-        /// This defaults to "AspNet.Identity.SecurityStamp".
-        /// </remarks>
         public string SecurityStampClaimType { get; set; } = "AspNet.Identity.SecurityStamp";
     }
 }

--- a/src/Microsoft.Extensions.Identity.Core/LockoutOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/LockoutOptions.cs
@@ -10,29 +10,27 @@ namespace Microsoft.AspNetCore.Identity
     /// </summary>
     public class LockoutOptions
     {
+        /// <summary>
+        /// Gets or sets a flag indicating whether a new user can be locked out. Defaults to true.
+        /// </summary>
         /// <value>
-        /// True if a newly created user can be locked out, otherwise false.
+        /// True if a newly created user can be locked out, otherwise false.  
         /// </value>
-        /// <remarks>
-        /// Defaults to true.
-        /// </remarks>
         public bool AllowedForNewUsers { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the number of failed access attempts allowed before a user is locked out,
-        /// assuming lock out is enabled.
+        /// assuming lock out is enabled. Defaults to 5.
         /// </summary>
         /// <value>
         /// The number of failed access attempts allowed before a user is locked out, if lockout is enabled.
         /// </value>
-        /// <remarks>Defaults to 5 failed attempts before an account is locked out.</remarks>
         public int MaxFailedAccessAttempts { get; set; } = 5;
 
         /// <summary>
-        /// Gets or sets the <see cref="TimeSpan"/> a user is locked out for when a lockout occurs.
+        /// Gets or sets the <see cref="TimeSpan"/> a user is locked out for when a lockout occurs. Defaults to 5 minutes.
         /// </summary>
         /// <value>The <see cref="TimeSpan"/> a user is locked out for when a lockout occurs.</value>
-        /// <remarks>Defaults to 5 minutes.</remarks>
         public TimeSpan DefaultLockoutTimeSpan { get; set; } = TimeSpan.FromMinutes(5);
     }
 }

--- a/src/Microsoft.Extensions.Identity.Core/PasswordHasherOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/PasswordHasherOptions.cs
@@ -13,25 +13,22 @@ namespace Microsoft.AspNetCore.Identity
         private static readonly RandomNumberGenerator _defaultRng = RandomNumberGenerator.Create(); // secure PRNG
 
         /// <summary>
-        /// Gets or sets the compatibility mode used when hashing passwords.
+        /// Gets or sets the compatibility mode used when hashing passwords. Defaults to 'ASP.NET Identity version 3'.
         /// </summary>
         /// <value>
         /// The compatibility mode used when hashing passwords.
         /// </value>
-        /// <remarks>
-        /// The default compatibility mode is 'ASP.NET Identity version 3'.
-        /// </remarks>
         public PasswordHasherCompatibilityMode CompatibilityMode { get; set; } = PasswordHasherCompatibilityMode.IdentityV3;
 
         /// <summary>
-        /// Gets or sets the number of iterations used when hashing passwords using PBKDF2.
+        /// Gets or sets the number of iterations used when hashing passwords using PBKDF2. Default is 10,000.
         /// </summary>
         /// <value>
         /// The number of iterations used when hashing passwords using PBKDF2.
         /// </value>
         /// <remarks>
         /// This value is only used when the compatibility mode is set to 'V3'.
-        /// The value must be a positive integer. The default value is 10,000.
+        /// The value must be a positive integer. 
         /// </remarks>
         public int IterationCount { get; set; } = 10000;
 

--- a/src/Microsoft.Extensions.Identity.Core/PasswordOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/PasswordOptions.cs
@@ -9,55 +9,37 @@ namespace Microsoft.AspNetCore.Identity
     public class PasswordOptions
     {
         /// <summary>
-        /// Gets or sets the minimum length a password must be.
+        /// Gets or sets the minimum length a password must be. Defaults to 6.
         /// </summary>
-        /// <remarks>
-        /// This defaults to 6.
-        /// </remarks>
         public int RequiredLength { get; set; } = 6;
 
         /// <summary>
-        /// Gets or sets the minimum number of unique chars a password must comprised of.
+        /// Gets or sets the minimum number of unique chars a password must comprised of. Defaults to 1.
         /// </summary>
-        /// <remarks>
-        /// This defaults to 1.
-        /// </remarks>
         public int RequiredUniqueChars { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets a flag indicating if passwords must contain a non-alphanumeric character.
+        /// Gets or sets a flag indicating if passwords must contain a non-alphanumeric character. Defaults to true.
         /// </summary>
         /// <value>True if passwords must contain a non-alphanumeric character, otherwise false.</value>
-        /// <remarks>
-        /// This defaults to true.
-        /// </remarks>
         public bool RequireNonAlphanumeric { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a flag indicating if passwords must contain a lower case ASCII character.
+        /// Gets or sets a flag indicating if passwords must contain a lower case ASCII character. Defaults to true.
         /// </summary>
         /// <value>True if passwords must contain a lower case ASCII character.</value>
-        /// <remarks>
-        /// This defaults to true.
-        /// </remarks>
         public bool RequireLowercase { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a flag indicating if passwords must contain a upper case ASCII character.
+        /// Gets or sets a flag indicating if passwords must contain a upper case ASCII character. Defaults to true.
         /// </summary>
         /// <value>True if passwords must contain a upper case ASCII character.</value>
-        /// <remarks>
-        /// This defaults to true.
-        /// </remarks>
         public bool RequireUppercase { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a flag indicating if passwords must contain a digit.
+        /// Gets or sets a flag indicating if passwords must contain a digit. Defaults to true.
         /// </summary>
         /// <value>True if passwords must contain a digit.</value>
-        /// <remarks>
-        /// This defaults to true.
-        /// </remarks>
         public bool RequireDigit { get; set; } = true;
     }
 }

--- a/src/Microsoft.Extensions.Identity.Core/SignInOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/SignInOptions.cs
@@ -9,13 +9,13 @@ namespace Microsoft.AspNetCore.Identity
     public class SignInOptions
     {
         /// <summary>
-        /// Gets or sets a flag indicating whether a confirmed email address is required to sign in.
+        /// Gets or sets a flag indicating whether a confirmed email address is required to sign in. Defaults to false.
         /// </summary>
         /// <value>True if a user must have a confirmed email address before they can sign in, otherwise false.</value>
         public bool RequireConfirmedEmail { get; set; }
 
         /// <summary>
-        /// Gets or sets a flag indicating whether a confirmed telephone number is required to sign in.
+        /// Gets or sets a flag indicating whether a confirmed telephone number is required to sign in. Defaults to false.
         /// </summary>
         /// <value>True if a user must have a confirmed telephone number before they can sign in, otherwise false.</value>
         public bool RequireConfirmedPhoneNumber { get; set; }

--- a/src/Microsoft.Extensions.Identity.Core/UserOptions.cs
+++ b/src/Microsoft.Extensions.Identity.Core/UserOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Identity
     public class UserOptions
     {
         /// <summary>
-        /// Gets or sets the list of allowed characters in the username used to validate user names.
+        /// Gets or sets the list of allowed characters in the username used to validate user names. Defaults to abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+
         /// </summary>
         /// <value>
         /// The list of allowed characters in the username used to validate user names.
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Identity
         public string AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
 
         /// <summary>
-        /// Gets or sets a flag indicating whether the application requires unique emails for its users.
+        /// Gets or sets a flag indicating whether the application requires unique emails for its users. Defaults to false.
         /// </summary>
         /// <value>
         /// True if the application requires each user to have their own, unique email, otherwise false.


### PR DESCRIPTION
- Move defaults from remarks to summary for better intellisense.
- Add summary to describe LockoutOptions AllowedForNewUsers.
- Added defaults to xml docs where missing.

Fixes #1426 