### PR TITLE
Fixed irritating typo in UserManager-docs

### DIFF
--- a/src/Microsoft.Extensions.Identity.Core/UserManager.cs
+++ b/src/Microsoft.Extensions.Identity.Core/UserManager.cs
@@ -854,7 +854,7 @@ namespace Microsoft.AspNetCore.Identity
         /// </summary>
         /// <param name="user">The user whose password should be reset.</param>
         /// <param name="token">The password reset token to verify.</param>
-        /// <param name="newPassword">The new password to set if reset token verification fails.</param>
+        /// <param name="newPassword">The new password to set if reset token verification succeeds.</param>
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.


### PR DESCRIPTION
Second try (without a typo in a typo-fix 😄)