### PR TITLE
Fix issue with AddEntityFrameworkStores and user only store

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityEntityFrameworkBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore/IdentityEntityFrameworkBuilderExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
                 else
                 {
-                    userStoreType = typeof(UserOnlyStore<,,,,,>).MakeGenericType(userType, roleType, contextType,
+                    userStoreType = typeof(UserOnlyStore<,,,,,>).MakeGenericType(userType, contextType,
                         identityContext.GenericTypeArguments[1],
                         identityContext.GenericTypeArguments[2],
                         identityContext.GenericTypeArguments[3],

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserOnlyTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserOnlyTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Identity.Test;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
+{
+    public class UserOnlyTest : IClassFixture<ScratchDatabaseFixture>
+    {
+        private readonly ApplicationBuilder _builder;
+        private const string DatabaseName = nameof(DefaultPocoTest);
+
+        public class TestUserDbContext : IdentityUserContext<IdentityUser>
+        {
+            public TestUserDbContext(DbContextOptions options) : base(options) { }
+        }
+
+        public UserOnlyTest(ScratchDatabaseFixture fixture)
+        {
+            var services = new ServiceCollection();
+
+            services
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                .AddDbContext<TestUserDbContext>(o => o.UseSqlServer(fixture.ConnectionString))
+                .AddIdentityCore<IdentityUser>(o => { })
+                .AddEntityFrameworkStores<TestUserDbContext>();
+
+            services.AddLogging();
+
+            var provider = services.BuildServiceProvider();
+            _builder = new ApplicationBuilder(provider);
+
+            using(var scoped = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            using (var db = scoped.ServiceProvider.GetRequiredService<TestUserDbContext>())
+            {
+                db.Database.EnsureCreated();
+            }
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        public async Task EnsureStartupUsageWorks()
+        {
+            var userStore = _builder.ApplicationServices.GetRequiredService<IUserStore<IdentityUser>>();
+            var userManager = _builder.ApplicationServices.GetRequiredService<UserManager<IdentityUser>>();
+
+            Assert.NotNull(userStore);
+            Assert.NotNull(userManager);
+
+            const string userName = "admin";
+            const string password = "1qaz@WSX";
+            var user = new IdentityUser { UserName = userName };
+            IdentityResultAssert.IsSuccess(await userManager.CreateAsync(user, password));
+            IdentityResultAssert.IsSuccess(await userManager.DeleteAsync(user));
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserOnlyTest.cs
+++ b/test/Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test/UserOnlyTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test
     public class UserOnlyTest : IClassFixture<ScratchDatabaseFixture>
     {
         private readonly ApplicationBuilder _builder;
-        private const string DatabaseName = nameof(DefaultPocoTest);
+        private const string DatabaseName = nameof(UserOnlyTest);
 
         public class TestUserDbContext : IdentityUserContext<IdentityUser>
         {


### PR DESCRIPTION
Fixes https://github.com/aspnet/Identity/issues/1480

Also patches test hole, the existing tests were using the store classes directly, rather than exercising the AddEntityFrameworkStores reflection logic so this code was never hit.

@ajcvickers 