### PR TITLE
Password validation failure does not propagate

### DIFF
--- a/src/Microsoft.AspNetCore.Identity.Specification.Tests/IdentityResultAssert.cs
+++ b/src/Microsoft.AspNetCore.Identity.Specification.Tests/IdentityResultAssert.cs
@@ -44,12 +44,16 @@ namespace Microsoft.AspNetCore.Identity.Test
         /// <summary>
         /// Asserts that the result has not Succeeded and that first error matches error's code and Description.
         /// </summary>
-        public static void IsFailure(IdentityResult result, IdentityError error)
+        public static void IsFailure(IdentityResult result, IdentityError error = null)
         {
             Assert.NotNull(result);
             Assert.False(result.Succeeded);
-            Assert.Equal(error.Description, result.Errors.First().Description);
-            Assert.Equal(error.Code, result.Errors.First().Code);
+
+            if (error != null)
+            { 
+                Assert.Equal(error.Description, result.Errors.FirstOrDefault()?.Description);
+                Assert.Equal(error.Code, result.Errors.FirstOrDefault()?.Code);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Identity.Core/UserManager.cs
+++ b/src/Microsoft.Extensions.Identity.Core/UserManager.cs
@@ -2438,15 +2438,21 @@ namespace Microsoft.AspNetCore.Identity
         protected async Task<IdentityResult> ValidatePasswordAsync(TUser user, string password)
         {
             var errors = new List<IdentityError>();
+            var isValid = true;
             foreach (var v in PasswordValidators)
             {
                 var result = await v.ValidateAsync(this, user, password);
                 if (!result.Succeeded)
                 {
-                    errors.AddRange(result.Errors);
+                    if (result.Errors.Any())
+                    {
+                        errors.AddRange(result.Errors);
+                    }
+
+                    isValid = false;
                 }
             }
-            if (errors.Count > 0)
+            if (!isValid)
             {
                 Logger.LogWarning(14, "User {userId} password validation failed: {errors}.", await GetUserIdAsync(user), string.Join(";", errors.Select(e => e.Code)));
                 return IdentityResult.Failed(errors.ToArray());


### PR DESCRIPTION
If validation fails, but no errors were returned in the Errors collection, add a default so the failure result propagates.