### PR TITLE
Use MSBuild to set NuGet feeds instead of NuGet.config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
 
   <Import Project="version.props" />
   <Import Project="build\dependencies.props" />
+  <Import Project="build\sources.props" />
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- Restore sources should be defined in build/sources.props. -->
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -1,0 +1,16 @@
+﻿<Project>
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup Label="RestoreSources">
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/NuGet.config
+++ b/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
FYI - @javiercn 

I noticed this repo had a reference to dotnet-core in a custom nuget.config file. I removed this as we need conditionally set feeds via MSBuild, and need to use the dependencies.props file in aspnet/Universe to mirror an partner team dependencies.