### PR TITLE
Mark Identity service packages as IsPackable=false

### DIFF
--- a/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
+++ b/src/Microsoft.AspNetCore.Diagnostics.Identity.Service/Microsoft.AspNetCore.Diagnostics.Identity.Service.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Service Diagnostics Middleware.</Description>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.Abstractions/Microsoft.AspNetCore.Identity.Service.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Abstractions/Microsoft.AspNetCore.Identity.Service.Abstractions.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core common types defining the main abstractions for Identity Service.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.AzureKeyVault/Microsoft.AspNetCore.Identity.Service.AzureKeyVault.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.AzureKeyVault/Microsoft.AspNetCore.Identity.Service.AzureKeyVault.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Azure Key Vault certificates support.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.Core/Microsoft.AspNetCore.Identity.Service.Core.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Core/Microsoft.AspNetCore.Identity.Service.Core.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core common types implementing the main abstractions for Identity Service.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore/Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Service implementation based on ASP.NET Core Identity.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient/Microsoft.AspNetCore.Identity.Service.IntegratedWebClient.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Service in process client.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -15,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Identity.Service\Microsoft.AspNetCore.Identity.Service.csproj" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Identity.Service.Mvc/Microsoft.AspNetCore.Identity.Service.Mvc.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Mvc/Microsoft.AspNetCore.Identity.Service.Mvc.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Service integration for ASP.NET Core MVC.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>Shared test suite for Asp.Net Identity Core as a service store implementations.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.AspNetCore.Identity.Service/Microsoft.AspNetCore.Identity.Service.csproj
+++ b/src/Microsoft.AspNetCore.Identity.Service/Microsoft.AspNetCore.Identity.Service.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
+    <!-- This project will not ship in 2.0.x -->
+    <IsPackable>false</IsPackable>
     <Description>ASP.NET Core Identity Service implementation based on Entity Framework.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
Marking the following packages as IsPackable=false so they aren't produced or built by CI. This also causes them to be excluded from our cascading version analysis.

⚠️ this ONLY APPLIES to the 2.0.x branch. I won't merge this back to dev.

- Microsoft.AspNetCore.Diagnostics.Identity.Service
- Microsoft.AspNetCore.Identity.Service.Abstractions
- Microsoft.AspNetCore.Identity.Service.AzureKeyVault
- Microsoft.AspNetCore.Identity.Service.Core
- Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore
- Microsoft.AspNetCore.Identity.Service.IntegratedWebClient
- Microsoft.AspNetCore.Identity.Service.Mvc
- Microsoft.AspNetCore.Identity.Service.Specification.Tests
- Microsoft.AspNetCore.Identity.Service