### PR TITLE
[Fixes #1628] Avoid stomping on an existing FileProvider

### DIFF
--- a/src/UI/IdentityDefaultUIConfigureOptions.cs
+++ b/src/UI/IdentityDefaultUIConfigureOptions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Identity.UI
                 throw new InvalidOperationException("Missing FileProvider.");
             }
 
-            options.FileProvider = Environment.WebRootFileProvider;
+            options.FileProvider = options.FileProvider ?? Environment.WebRootFileProvider;
 
             // Add our provider
             var filesProvider = new ManifestEmbeddedFileProvider(GetType().Assembly, "wwwroot");


### PR DESCRIPTION
Respects the existing one if it's there.