### PR TITLE
Add AddDefaultIdentity() method

### DIFF
--- a/samples/IdentitySample.DefaultUI/Startup.cs
+++ b/samples/IdentitySample.DefaultUI/Startup.cs
@@ -34,18 +34,9 @@ namespace IdentitySample.DefaultUI
 
             services.AddMvc();
 
-            services.AddIdentityCore<ApplicationUser>(o => o.Stores.MaxLengthForKeys = 128)
+            services.AddDefaultIdentity<ApplicationUser>()
                  .AddRoles<IdentityRole>()
-                 .AddEntityFrameworkStores<ApplicationDbContext>()
-                 .AddDefaultUI()
-                 .AddDefaultTokenProviders();
-
-            services.AddAuthentication(o =>
-            {
-                o.DefaultScheme = IdentityConstants.ApplicationScheme;
-                o.DefaultSignInScheme = IdentityConstants.ExternalScheme;
-            })
-            .AddIdentityCookies(o => { });
+                 .AddEntityFrameworkStores<ApplicationDbContext>();
         }
 
  

--- a/src/UI/IdentityServiceCollectionUIExtensions.cs
+++ b/src/UI/IdentityServiceCollectionUIExtensions.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Identity.UI;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.AspNetCore.Identity
+{
+    /// <summary>
+    /// Default UI extensions to <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class IdentityServiceCollectionUIExtensions
+    {
+        /// <summary>
+        /// Adds a set of common identity services to the application, including a default UI, token providers,
+        /// and configures authentication to use identity cookies.
+        /// </summary>
+        /// <remarks>
+        /// In order to use the default UI, the application must be using <see cref="Microsoft.AspNetCore.Mvc"/>,
+        /// <see cref="Microsoft.AspNetCore.StaticFiles"/> and contain a <c>_LoginPartial</c> partial view that
+        /// can be found by the application.
+        /// </remarks>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IdentityBuilder AddDefaultIdentity<TUser>(this IServiceCollection services) where TUser : class
+            => services.AddDefaultIdentity<TUser>(_ => { });
+
+        /// <summary>
+        /// Adds a set of common identity services to the application, including a default UI, token providers,
+        /// and configures authentication to use identity cookies.
+        /// </summary>
+        /// <remarks>
+        /// In order to use the default UI, the application must be using <see cref="Microsoft.AspNetCore.Mvc"/>,
+        /// <see cref="Microsoft.AspNetCore.StaticFiles"/> and contain a <c>_LoginPartial</c> partial view that
+        /// can be found by the application.
+        /// </remarks>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureOptions">Configures the <see cref="IdentityOptions"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IdentityBuilder AddDefaultIdentity<TUser>(this IServiceCollection services, Action<IdentityOptions> configureOptions) where TUser : class
+        {
+            services.AddAuthentication(o =>
+            {
+                o.DefaultScheme = IdentityConstants.ApplicationScheme;
+                o.DefaultSignInScheme = IdentityConstants.ExternalScheme;
+            })
+            .AddIdentityCookies(o => { });
+
+            return services.AddIdentityCore<TUser>(o =>
+            {
+                o.Stores.MaxLengthForKeys = 128;
+                configureOptions?.Invoke(o);
+            })
+                .AddDefaultUI()
+                .AddDefaultTokenProviders();
+        }
+    }
+}

--- a/test/WebSites/Identity.DefaultUI.WebSite/Startup.cs
+++ b/test/WebSites/Identity.DefaultUI.WebSite/Startup.cs
@@ -35,18 +35,9 @@ namespace Identity.DefaultUI.WebSite
                     sqlOptions => sqlOptions.MigrationsAssembly("Identity.DefaultUI.WebSite")
                 ));
 
-            services.AddIdentityCore<IdentityUser>()
+            services.AddDefaultIdentity<IdentityUser>()
                 .AddRoles<IdentityRole>()
-                .AddEntityFrameworkStores<IdentityDbContext>()
-                .AddDefaultUI()
-                .AddDefaultTokenProviders();
-
-            services.AddAuthentication(o =>
-            {
-                o.DefaultScheme = IdentityConstants.ApplicationScheme;
-                o.DefaultSignInScheme = IdentityConstants.ExternalScheme;
-            })
-                .AddIdentityCookies(o => {});
+                .AddEntityFrameworkStores<IdentityDbContext>();
 
             services.AddMvc()
                 .AddRazorPagesOptions(options =>

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.1.0</VersionPrefix>
-    <VersionSuffix>preview2</VersionSuffix>
+    <VersionSuffix>preview3</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.1.0</VersionPrefix>
-    <VersionSuffix>preview3</VersionSuffix>
+    <VersionSuffix>preview2</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
- Fixes https://github.com/aspnet/Identity/issues/1625
- Adds new template sugar method (AddIdentityV2) basically.
- Roles are now not included by default, can be easily added back via `.AddRoles<IdentityRole>()`
- Note this has to live in the UI package since that's the leaf package that has everything.
- Still clobbers the authentication schemes to point to identity cookies, we'll revisit that in 2.2
- Rolls the MaxKeyLength into a hidden default in the sugar method (should we set it only in the args less overload?)

@ajcvickers @blowdart @javiercn 