### PR TITLE
Include social logins and authenticator key as part of personal download

### DIFF
--- a/src/Stores/IdentityUserToken.cs
+++ b/src/Stores/IdentityUserToken.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <summary>
         /// Gets or sets the token value.
         /// </summary>
+        [ProtectedPersonalData]
         public virtual string Value { get; set; }
     }
 }

--- a/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
@@ -58,6 +58,12 @@ namespace Microsoft.AspNetCore.Identity.UI.Pages.Account.Manage.Internal
                 personalData.Add(p.Name, p.GetValue(user)?.ToString() ?? "null");
             }
 
+            var logins = await _userManager.GetLoginsAsync(user);
+            foreach (var l in logins)
+            {
+                personalData.Add($"{l.LoginProvider} external login provider key", l.ProviderKey);
+            }
+
             personalData.Add($"Authenticator Key", await _userManager.GetAuthenticatorKeyAsync(user));
 
             Response.Headers.Add("Content-Disposition", "attachment; filename=PersonalData.json");

--- a/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
@@ -58,12 +58,6 @@ namespace Microsoft.AspNetCore.Identity.UI.Pages.Account.Manage.Internal
                 personalData.Add(p.Name, p.GetValue(user)?.ToString() ?? "null");
             }
 
-            var logins = await _userManager.GetLoginsAsync(user);
-            foreach (var l in logins)
-            {
-                personalData.Add($"{l.LoginProvider} external login provider key", l.ProviderKey);
-            }
-
             personalData.Add($"Authenticator Key", await _userManager.GetAuthenticatorKeyAsync(user));
 
             Response.Headers.Add("Content-Disposition", "attachment; filename=PersonalData.json");

--- a/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs
@@ -51,13 +51,20 @@ namespace Microsoft.AspNetCore.Identity.UI.Pages.Account.Manage.Internal
 
             // Only include personal data for download
             var personalData = new Dictionary<string, string>();
-
             var personalDataProps = typeof(TUser).GetProperties().Where(
                             prop => Attribute.IsDefined(prop, typeof(PersonalDataAttribute)));
             foreach (var p in personalDataProps)
             {
                 personalData.Add(p.Name, p.GetValue(user)?.ToString() ?? "null");
             }
+
+            var logins = await _userManager.GetLoginsAsync(user);
+            foreach (var l in logins)
+            {
+                personalData.Add($"{l.LoginProvider} external login provider key", l.ProviderKey);
+            }
+
+            personalData.Add($"Authenticator Key", await _userManager.GetAuthenticatorKeyAsync(user));
 
             Response.Headers.Add("Content-Disposition", "attachment; filename=PersonalData.json");
             return new FileContentResult(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(personalData)), "text/json");


### PR DESCRIPTION
We now display the linked login providers and the authenticator key if it exists.

Apps will be responsible for displaying any additional custom tokens they might store (like access/refresh tokens) since we don't have any way of enumerating these today.

@blowdart @ajcvickers 