### PR TITLE
AllowAnonymous for external login providers and confirm email

### DIFF
--- a/src/UI/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.AspNetCore.Identity.UI.Pages.Account.Internal
 {
+    [AllowAnonymous]
     [IdentityDefaultUI(typeof(ConfirmEmailModel<>))]
     public abstract class ConfirmEmailModel : PageModel
     {

--- a/src/UI/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -6,12 +6,14 @@ using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Identity.UI.Pages.Account.Internal
 {
+    [AllowAnonymous]
     [IdentityDefaultUI(typeof(ExternalLoginModel<>))]
     public class ExternalLoginModel : PageModel
     {

--- a/test/Identity.FunctionalTests/LoginTests.cs
+++ b/test/Identity.FunctionalTests/LoginTests.cs
@@ -8,7 +8,6 @@ using Identity.DefaultUI.WebSite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Identity.FunctionalTests
@@ -30,6 +29,29 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
             // Arrange
             var client = ServerFactory.CreateClient();
             var newClient = ServerFactory.CreateClient();
+
+            var userName = $"{Guid.NewGuid()}@example.com";
+            var password = $"!Test.Password1$";
+
+            // Act & Assert
+            await UserStories.RegisterNewUserAsync(client, userName, password);
+
+            // Use a new client to simulate a new browser session.
+            await UserStories.LoginExistingUserAsync(newClient, userName, password);
+        }
+
+        [Fact]
+        public async Task CanLogInWithAPreviouslyRegisteredUser_WithGlobalAuthorizeFilter()
+        {
+            // Arrange
+            void ConfigureTestServices(IServiceCollection services) =>
+                services.SetupGlobalAuthorizeFilter();
+
+            var server = ServerFactory
+                .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
+
+            var client = server.CreateClient();
+            var newClient = server.CreateClient();
 
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
@@ -65,8 +87,14 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
         public async Task CanLogInWithTwoFactorAuthentication_WithGlobalAuthorizeFilter()
         {
             // Arrange
-            var client = ServerFactory.CreateClient();
-            var newClient = ServerFactory.CreateClient();
+            void ConfigureTestServices(IServiceCollection services) =>
+                services.SetupGlobalAuthorizeFilter();
+
+            var server = ServerFactory
+                .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
+
+            var client = server.CreateClient();
+            var newClient = server.CreateClient();
 
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = $"!Test.Password1$";
@@ -130,11 +158,35 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
         public async Task CannotLogInWithoutRequiredEmailConfirmation()
         {
             // Arrange
-
             var emailSender = new ContosoEmailSender();
             void ConfigureTestServices(IServiceCollection services) => services
                     .SetupTestEmailSender(emailSender)
                     .SetupEmailRequired();
+
+            var server = ServerFactory.WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
+
+            var client = server.CreateClient();
+            var newClient = server.CreateClient();
+
+            var userName = $"{Guid.NewGuid()}@example.com";
+            var password = $"!Test.Password1$";
+
+            var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+
+            // Act & Assert
+            // Use a new client to simulate a new browser session.
+            await Assert.ThrowsAnyAsync<XunitException>(() => UserStories.LoginExistingUserAsync(newClient, userName, password));
+        }
+
+        [Fact]
+        public async Task CannotLogInWithoutRequiredEmailConfirmation_WithGlobalAuthorizeFilter()
+        {
+            // Arrange
+            var emailSender = new ContosoEmailSender();
+            void ConfigureTestServices(IServiceCollection services) => services
+                    .SetupTestEmailSender(emailSender)
+                    .SetupEmailRequired()
+                    .SetupGlobalAuthorizeFilter();
 
             var server = ServerFactory.WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
 

--- a/test/Identity.FunctionalTests/RegistrationTests.cs
+++ b/test/Identity.FunctionalTests/RegistrationTests.cs
@@ -38,12 +38,51 @@ namespace Microsoft.AspNetCore.Identity.FunctionalTests
         }
 
         [Fact]
+        public async Task CanRegisterAUser_WithGlobalAuthorizeFilter()
+        {
+            // Arrange
+            void ConfigureTestServices(IServiceCollection services) =>
+                services.SetupGlobalAuthorizeFilter();
+
+            var client = ServerFactory
+                    .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
+                    .CreateClient();
+
+            var userName = $"{Guid.NewGuid()}@example.com";
+            var password = $"!Test.Password1$";
+
+            // Act & Assert
+            await UserStories.RegisterNewUserAsync(client, userName, password);
+        }
+
+        [Fact]
         public async Task CanRegisterWithASocialLoginProvider()
         {
             // Arrange
             void ConfigureTestServices(IServiceCollection services) =>
                 services
                     .SetupTestThirdPartyLogin();
+
+            var client = ServerFactory
+                .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
+                .CreateClient();
+
+            var guid = Guid.NewGuid();
+            var userName = $"{guid}";
+            var email = $"{guid}@example.com";
+
+            // Act & Assert
+            await UserStories.RegisterNewUserWithSocialLoginAsync(client, userName, email);
+        }
+
+        [Fact]
+        public async Task CanRegisterWithASocialLoginProvider_WithGlobalAuthorizeFilter()
+        {
+            // Arrange
+            void ConfigureTestServices(IServiceCollection services) =>
+                services
+                    .SetupTestThirdPartyLogin()
+                    .SetupGlobalAuthorizeFilter();
 
             var client = ServerFactory
                 .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))

--- a/test/WebSites/Identity.DefaultUI.WebSite/Pages/Contoso/Login.cshtml.cs
+++ b/test/WebSites/Identity.DefaultUI.WebSite/Pages/Contoso/Login.cshtml.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 
 namespace Identity.DefaultUI.WebSite.Pages
 {
+    [AllowAnonymous]
     public class LoginModel : PageModel
     {
         public LoginModel(IOptionsMonitor<ContosoAuthenticationOptions> options)


### PR DESCRIPTION
Addresses #1762

While using the global authorization filter, `ConfirmEmail` is not accessible when clicking the verification email link (when logged out). So adding the attribute to it as well.

