### PR TITLE
More specific search for the keys of userid and roleid in FindUserRoleAsync

### DIFF
--- a/src/EF/UserStore.cs
+++ b/src/EF/UserStore.cs
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore
         /// <returns>The user role if it exists.</returns>
         protected override Task<TUserRole> FindUserRoleAsync(TKey userId, TKey roleId, CancellationToken cancellationToken)
         {
-            return UserRoles.FindAsync(new object[] { userId, roleId }, cancellationToken);
+            return UserRoles.SingleOrDefaultAsync(r => r.UserId.Equals(userId) && r.RoleId.Equals(roleId), cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
My UserRole-Table was created by the following auto-generated migration code:

`migrationBuilder.CreateTable(
                name: "UserRole",
                schema: "Security",
                columns: table => new
                {
                    RoleId = table.Column<int>(nullable: false),
                    UserId = table.Column<int>(nullable: false)
                },
                constraints: table =>
                {
                    table.PrimaryKey("PK_UserRole", x => new { x.RoleId, x.UserId });
                    table.UniqueConstraint("AK_UserRole_UserId_RoleId", x => new { x.UserId, x.RoleId });
                    table.ForeignKey(
                        name: "FK_UserRole_Role_RoleId",
                        column: x => x.RoleId,
                        principalSchema: "Security",
                        principalTable: "Role",
                        principalColumn: "Id",
                        onDelete: ReferentialAction.Cascade);
                    table.ForeignKey(
                        name: "FK_UserRole_Users_UserId",
                        column: x => x.UserId,
                        principalSchema: "Security",
                        principalTable: "Users",
                        principalColumn: "Id",
                        onDelete: ReferentialAction.Cascade);
                });`

**I am using int-based Id-Fields.**

This code specifies my primary key like this:
`table.PrimaryKey("PK_UserRole", x => new { x.RoleId, x.UserId }); `.
The `UserStore` searches for `UserRole` like this: 
`UserRoles.FindAsync(new object[] { userId, roleId }, cancellationToken);`

The keys of the primary key are swapped, leading to random behaviour of some user manager functions e.g. `RemoveFromRoleAsync(..)`, `AddToRoleAsync(..)`, ..

My solution with 
`SingleOrDefaultAsync(r => r.UserId.Equals(userId) && r.RoleId.Equals(roleId)` 
searches for the `UserRole` independent of the primary key order.