### PR TITLE
Fix ActivePage declarations

### DIFF
--- a/src/UI/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -2,6 +2,7 @@
 @model ChangePasswordModel
 @{
     ViewData["Title"] = "Change password";
+    ViewData["ActivePage"] = ManageNavPages.ChangePassword;
 }
 
 <h4>@ViewData["Title"]</h4>

--- a/src/UI/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml
@@ -2,7 +2,7 @@
 @model DeletePersonalDataModel
 @{
     ViewData["Title"] = "Delete Personal Data";
-    ViewData["ActivePage"] = ManageNavPages.DeletePersonalData;
+    ViewData["ActivePage"] = ManageNavPages.PersonalData;
 }
 
 <h4>@ViewData["Title"]</h4>

--- a/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml
@@ -2,7 +2,7 @@
 @model DownloadPersonalDataModel
 @{
     ViewData["Title"] = "Download Your Data";
-    ViewData["ActivePage"] = ManageNavPages.DownloadPersonalData;
+    ViewData["ActivePage"] = ManageNavPages.PersonalData;
 }
 
 <h4>@ViewData["Title"]</h4>

--- a/src/UI/Areas/Identity/Pages/Account/Manage/ExternalLogins.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/ExternalLogins.cshtml
@@ -2,6 +2,7 @@
 @model ExternalLoginsModel
 @{
     ViewData["Title"] = "Manage your external logins";
+    ViewData["ActivePage"] = ManageNavPages.ExternalLogins;
 }
 
 @Html.Partial("_StatusMessage", Model.StatusMessage)

--- a/src/UI/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -2,6 +2,7 @@
 @model IndexModel
 @{
     ViewData["Title"] = "Profile";
+    ViewData["ActivePage"] = ManageNavPages.Index;
 }
 
 <h4>@ViewData["Title"]</h4>

--- a/src/UI/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml
+++ b/src/UI/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml
@@ -2,6 +2,7 @@
 @model TwoFactorAuthenticationModel
 @{
     ViewData["Title"] = "Two-factor authentication (2FA)";
+    ViewData["ActivePage"] = ManageNavPages.TwoFactorAuthentication;
 }
 
 @Html.Partial("_StatusMessage", Model.StatusMessage)


### PR DESCRIPTION
* Some of the `ViewData["ActivePage"]` declarations were missing.
* `DeletePersonalData` and `DownloadPersonalData` should set `ActivePage` to `PersonalData` as there is no navigation element for `DeletePersonalData` or `DownloadPersonalData`.
* Remove `DeletePersonalData` and `DownloadPersonalData` variables and methods as they're no longer used by anthing.
* Make `PageNavClass` private as it is never used outside of its class.