### PR TITLE
Disable parallelization

### DIFF
--- a/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
@@ -4,4 +4,5 @@
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
+// Caused test issues. See https://github.com/aspnet/Identity/issues/1926
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Identity.FunctionalTests/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
-// Caused test issues. See https://github.com/aspnet/Identity/issues/1926
+// Caused OOM test issues with file watcher. See https://github.com/aspnet/Identity/issues/1926
 [assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
For https://github.com/aspnet/Identity/issues/1926

Test running time go from 17s -> 29s locally

@Eilon @ajcvickers 