### PR TITLE
[Design] Add UI user factory

### DIFF
--- a/src/UI/Areas/Identity/Pages/V3/Account/Register.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/V3/Account/Register.cshtml.cs
@@ -52,22 +52,20 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
     {
         private readonly SignInManager<TUser> _signInManager;
         private readonly UserManager<TUser> _userManager;
-        private readonly IUserStore<TUser> _userStore;
-        private readonly IUserEmailStore<TUser> _emailStore;
+        private readonly IdentityDefaultUIUserFactory<TUser> _userFactory;
         private readonly ILogger<LoginModel> _logger;
         private readonly IEmailSender _emailSender;
 
         public RegisterModel(
             UserManager<TUser> userManager,
-            IUserStore<TUser> userStore,
             SignInManager<TUser> signInManager,
+            IdentityDefaultUIUserFactory<TUser> userFactory,
             ILogger<LoginModel> logger,
             IEmailSender emailSender)
         {
             _userManager = userManager;
-            _userStore = userStore;
-            _emailStore = GetEmailStore();
             _signInManager = signInManager;
+            _userFactory = userFactory;
             _logger = logger;
             _emailSender = emailSender;
         }
@@ -82,10 +80,8 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
             returnUrl = returnUrl ?? Url.Content("~/");
             if (ModelState.IsValid)
             {
-                var user = CreateUser();
-
-                await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
-                await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+                // By default we use the email for the user name and the email
+                var user = _userFactory.Create(Input.Email, Input.Email);
                 var result = await _userManager.CreateAsync(user, Input.Password);
 
                 if (result.Succeeded)
@@ -114,29 +110,6 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
 
             // If we got this far, something failed, redisplay form
             return Page();
-        }
-
-        private TUser CreateUser()
-        {
-            try
-            {
-                return Activator.CreateInstance<TUser>();
-            }
-            catch
-            {
-                throw new InvalidOperationException($"Can't create an instance of '{nameof(TUser)}'. " +
-                    $"Ensure that '{nameof(TUser)}' is not an abstract class and has a parameterless constructor, or alternatively " +
-                    $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
-            }
-        }
-
-        private IUserEmailStore<TUser> GetEmailStore()
-        {
-            if (!_userManager.SupportsUserEmail)
-            {
-                throw new NotSupportedException("The default UI requires a user store with email support.");
-            }
-            return (IUserEmailStore<TUser>)_userStore;
         }
     }
 }

--- a/src/UI/DefaultUserFactory.cs
+++ b/src/UI/DefaultUserFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Identity.UI
+{
+    public class FuncUserFactory<TUser> : IdentityDefaultUIUserFactory<TUser> where TUser : class
+    {
+        private readonly Func<string, string, TUser> _createFunc;
+
+        public FuncUserFactory(Func<string, string, TUser> createFunc)
+            => _createFunc = createFunc;
+
+        public override TUser Create(string userName, string email)
+            => _createFunc(userName, email);
+    }
+
+
+    /// <summary>
+    /// Options for the default Identity UI
+    /// </summary>
+    public class DefaultUserFactory<TUser, TKey> : IdentityDefaultUIUserFactory<TUser> where TUser : IdentityUser<TKey>, new() where TKey : IEquatable<TKey>
+    {
+        public override TUser Create(string userName, string email)
+        {
+            var user = new TUser();
+            user.UserName = userName;
+            user.Email = email;
+            return user;
+        }
+    }
+}

--- a/src/UI/IdentityDefaultUIUserFactory.cs
+++ b/src/UI/IdentityDefaultUIUserFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Identity.UI
+{
+    /// <summary>
+    /// Used by the register page to create a new instance of a user.
+    /// </summary>
+    /// <typeparam name="TUser">The type of the user to create.</typeparam>
+    public abstract class IdentityDefaultUIUserFactory<TUser> where TUser : class
+    {
+        /// <summary>
+        /// Creates a new instance of a user.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="email">The user's email.</param>
+        /// <returns></returns>
+        public abstract TUser Create(string userName, string email);
+    }
+}

--- a/test/WebSites/Identity.DefaultUI.WebSite/PocoUserStartup.cs
+++ b/test/WebSites/Identity.DefaultUI.WebSite/PocoUserStartup.cs
@@ -28,7 +28,13 @@ namespace Identity.DefaultUI.WebSite
 
             services.AddDefaultIdentity<Microsoft.AspNetCore.Identity.Test.PocoUser>()
                 .AddDefaultUI(UIFramework.Bootstrap4)
-                .AddUserManager<UserManager<Microsoft.AspNetCore.Identity.Test.PocoUser>>();
+                .AddUserManager<UserManager<Microsoft.AspNetCore.Identity.Test.PocoUser>>()
+                .AddDefaultUIUserFactory<Microsoft.AspNetCore.Identity.Test.PocoUser>((userName,email) =>
+                    new Microsoft.AspNetCore.Identity.Test.PocoUser()
+                    {
+                        UserName = userName,
+                        Email = email
+                    });
             services.AddSingleton<IUserStore<Microsoft.AspNetCore.Identity.Test.PocoUser>, InMemoryUserStore<Microsoft.AspNetCore.Identity.Test.PocoUser>>();
 
             services.AddMvc();


### PR DESCRIPTION
Exploring fixes for https://github.com/aspnet/Identity/issues/1722

Not sure if this might be more appropriate for 3.0 as its will be hard to do this in a non breaking change way in 2.2, basically moves away from Activator.CreateInstance infavor of a dedicated DefaultUIUserFactory which will be used to create new user instances. 

We provide a default one that works for identity user based classes that have a default constructor, custom users can add their own factory implementation that implements:
 `TUser Create(string userName, string email)`

or they can just register it inline like so with a sugar method:
```
            services.AddDefaultIdentity<PocoUser>()
                .AddUserManager<UserManager<PocoUser>>()
                .AddDefaultUIUserFactory<PocoUser>((userName,email) =>
                    new PocoUser()
                    {
                        UserName = userName,
                        Email = email
                    });
```

Thoughts @ajcvickers @javiercn @blowdart 