### PR TITLE
Change spec test packages to depend on xunit.execution.core, not the xunit metapackage

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -70,6 +70,8 @@
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>4.5.0</SystemComponentModelAnnotationsPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
+    <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
+    <XunitExtensibilityCorePackageVersion>2.3.1</XunitExtensibilityCorePackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/src/Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
+++ b/src/Service.Specification.Tests/Microsoft.AspNetCore.Identity.Service.Specification.Tests.csproj
@@ -20,7 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Specification.Tests/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -16,7 +16,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Per xunit guidance, packages which deliver xunit bits shouldn't also depend on the xunit metapackage.

> https://xunit.github.io/releases/2.3:
> As a reminder: If you're extending xUnit.net and want to publish your extension as a NuGet package, you should import xunit.extensibility.core and/or xunit.extensibility.execution, not xunit or xunit.core. If you do this wrong, you might have problems generating your NuGet package via dotnet pack.

