### PR TITLE
Add missing "private readonly" modifiers to _userManager and _logger fields

### DIFF
--- a/src/UI/Areas/Identity/Pages/V4/Account/Manage/ResetAuthenticator.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/V4/Account/Manage/ResetAuthenticator.cshtml.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
 
     internal class ResetAuthenticatorModel<TUser> : ResetAuthenticatorModel where TUser : class
     {
-        UserManager<TUser> _userManager;
+        private readonly UserManager<TUser> _userManager;
         private readonly SignInManager<TUser> _signInManager;
-        ILogger<ResetAuthenticatorModel> _logger;
+        private readonly ILogger<ResetAuthenticatorModel> _logger;
 
         public ResetAuthenticatorModel(
             UserManager<TUser> userManager,


### PR DESCRIPTION
Two small fixes for missing "private readonly" modifiers in Identity UI.