### PR TITLE
Use the correct logging category inside RegisterModel

### DIFF
--- a/src/UI/Areas/Identity/Pages/V3/Account/Register.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/V3/Account/Register.cshtml.cs
@@ -54,14 +54,14 @@ namespace Microsoft.AspNetCore.Identity.UI.V3.Pages.Account.Internal
         private readonly UserManager<TUser> _userManager;
         private readonly IUserStore<TUser> _userStore;
         private readonly IUserEmailStore<TUser> _emailStore;
-        private readonly ILogger<LoginModel> _logger;
+        private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
 
         public RegisterModel(
             UserManager<TUser> userManager,
             IUserStore<TUser> userStore,
             SignInManager<TUser> signInManager,
-            ILogger<LoginModel> logger,
+            ILogger<RegisterModel> logger,
             IEmailSender emailSender)
         {
             _userManager = userManager;

--- a/src/UI/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
+++ b/src/UI/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
@@ -54,14 +54,14 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal
         private readonly UserManager<TUser> _userManager;
         private readonly IUserStore<TUser> _userStore;
         private readonly IUserEmailStore<TUser> _emailStore;
-        private readonly ILogger<LoginModel> _logger;
+        private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
 
         public RegisterModel(
             UserManager<TUser> userManager,
             IUserStore<TUser> userStore,
             SignInManager<TUser> signInManager,
-            ILogger<LoginModel> logger,
+            ILogger<RegisterModel> logger,
             IEmailSender emailSender)
         {
             _userManager = userManager;


### PR DESCRIPTION
This pull-request fixes the logging category when messages are logged from the ASP.NET Identity UI Register page. Should be a non-breaking change.