### PR TITLE
Ensure ApiAuthorization.IdentityServer doesn't build a 2.2.0 package with the rest of RTM

### DIFF
--- a/src/ApiAuth.IS/Microsoft.AspNetCore.ApiAuthorization.IdentityServer.csproj
+++ b/src/ApiAuth.IS/Microsoft.AspNetCore.ApiAuthorization.IdentityServer.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- This package is going to ship out of band with 2.2 RTM, so this ensures we don't build a "2.2.0" package with the rest of the runtime. -->
+    <PackageVersion>2.2.0-preview-$(BuildNumber)</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>ASP.NET Core API Authorization package powered by Identity Server.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This will prevent us from ending up with a "2.2.0" package when we do our final 2.2.0 RTM build, which would end up in build caches and drops. 